### PR TITLE
Small changes to .gitignore and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,21 +2,46 @@
 # Conventions vary, including env, venv, or longer names like cgap_env,
 # but typically they end in "env".
 *env/
+
+# Chalice support (for Foursight)
 .chalice/deployments/
 .chalice/deployed/
 .chalice/venv/
 .chalice/config.json
-dist/
+
+# Configuration
 requirements.txt
+config.json
+
+# Distribution / packaging
+dist/
+*.egg-info
+
+# Python
 *.pyc
+__pycache__/
+
+# Mac folder metadata
 .DS_Store
+
+# Credentials
 credentials.json
 token.pickle
-__pycache__/
+secrets.py
+
+# PyCharm metadata
 .idea/
+
+# Input and Output
+
 log/
 out/
 in/
-secrets.py
-config.json
 test_data/knowledge_base/temp-local-inserts/*
+DEBUGLOG-*
+*.log
+
+# Backup files (Emacs, etc.)
+*~
+~$*
+.~*#

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ default: info
 
 .PHONY: alpha legacy deploy-alpha-p1 deploy-alpha-p2 info
 
+build:
+	poetry install
+
 alpha:
 	@echo 'Validating CGAP-Portal Alpha'
 	poetry run cli provision network --validate --alpha
@@ -83,6 +86,7 @@ ingestion:
 info:
 	@: $(info Here are some 'make' options:)
 	   $(info - Use 'make alpha' to trigger validation of the alpha stack.)
+	   $(info - Use 'make build' to populate the current virtualenv with necessary libraries and commands.)
 	   $(info - Use 'make legacy' to trigger validation of the legacy stack.)
 	   $(info - Use 'make deploy-alpha-p1' to trigger phase 1 of the alpha deployment: change set upload of the IAM, Logging, Network, ECR and Datastore.)
 	   $(info - Use 'make deploy-alpha-p2' to trigger phase 2 of the alpha deployment: application version upload to ECR, ECS provisioning.)


### PR DESCRIPTION
This is just light housekeeping:

* Adds a few things to .gitignore like support for Emacs backup files.
* Rearranges .gitignore to have comments about what some of the stuff is for.
* Adds a `build` target to the `Makefile` so that a `venv` can be populated in the usual way we like.

