### PR TITLE
Add opt-in human AWS diagnosis and remediation roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Project agent memory
+
+- CI setup and its required dummy `custom/config.json` / `custom/secrets.json` are in `.github/workflows/main.yml`; reproduce with locked dependencies and `pytest tests src/tests`. Missing config can mask actual failures with import/collection errors. `poetry.toml` disables automatic virtualenv creation, so establish an isolated environment first.
+- For offline validation, synthesize in-process and use local `cfn-lint`, with fake credentials and network/SDK calls blocked. `make alpha` and `cli provision --validate` contact CloudFormation; they are not offline checks. Foursight packaging and some export lookups require deployed infrastructure.
+- `ConfigManager` in `src/base.py` stringifies JSON values; many part attributes resolve config at import time. Establish app/deployment settings before importing stack modules (use separate processes for configuration matrices).
+- Use the naming helpers in `src/names.py` when seeding AWS mocks, rather than reconstructing legacy names. In particular, GAC secrets belong to the appconfig stack, not the datastore naming scheme.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ For an in-depth overview, see `docs/architecture.rst`.
 ## Human Direct AWS Access Roles
 
 Two **optional, disabled-by-default** IAM roles let people work directly in AWS without assuming
-`*DevRole` (which is trusted by the account root and carries ten full-access managed policies):
+`*DevRole` (which trusts the account root and carries ten AWS managed policies plus runtime policies):
 
 | Role | Purpose |
 |---|---|
 | `*DevDiagnoseRole` | Read-only inspection of the running system |
-| `*PowerRemediateRole` | The reversible operational actions needed to remediate those same services |
+| `*PowerRemediateRole` | Operational API access, including privileged build/workflow delegation |
 
 They are built by `C4IAM` in `src/parts/iam.py` and live in the IAM stack. With none of the
 `human_access.*` settings present in `template.config.json` the IAM template is byte-for-byte what
@@ -58,18 +58,12 @@ no account-root trust fallback. See `docs/source/human_access_roles.rst` for the
 
 ### Scoping model: service-level resources, tightly constrained actions
 
-This account holds only our own resources, so these policies **do not enumerate resource
-identifiers**. Two rules apply instead:
-
-1. **Where an action supports resource-level authorization, the resource is scoped to the
-   service** - `arn:aws:ecs:<region>:<account-id>:service/*`, `arn:aws:s3:::*/*`,
-   `arn:aws:secretsmanager:<region>:<account-id>:secret:*`, and so on. That means every resource of
-   that type in this account and region, and nothing outside it.
-2. **Where an action has no resource-level authorization at all** - `ecs:Describe*`,
-   `cloudwatch:GetMetricData`, `ec2:Describe*`, `sqs:ListQueues`, `sts:GetCallerIdentity` and
-   friends - AWS accepts only `"*"`. Those live in a single clearly named read-only statement per
-   role (`InspectServiceStateAcrossSupportedServices`, `ReadsNeededToTargetARemediation`) and are
-   constrained by an `aws:RequestedRegion` condition instead.
+These policies **do not enumerate resource identifiers**. Account/region service-level ARNs
+scope resource reads and operational actions. S3 additionally requires `s3:ResourceAccount`
+and explicitly denies other owners because S3 ARNs contain no account field. Remaining
+wildcard discovery/inspection groups use `aws:RequestedRegion` and check `aws:ResourceAccount`
+when AWS supplies it; not every inventory request carries resource ownership. See the operator
+documentation for the exact scope and limits rather than inferring them from a statement name.
 
 So the real constraint is **the action list**, which is fully enumerated - no `ecs:*`, no
 `s3:*`, and never `"Action": "*"` in either role. Every action is individually listed and
@@ -77,18 +71,24 @@ justified by a supported service. Both roles also carry a permission boundary; n
 permission boundary is a **ceiling, not a grant** - it must open with an `Allow` or the roles could
 do nothing at all, and it does not widen either role.
 
-What both roles are prevented from doing, by their own `Deny` statements and by the boundary: IAM
-or Identity Center administration, CloudFormation mutation, network/perimeter changes, authoring or
-running new code (`ecr:PutImage`, `ecs:RegisterTaskDefinition`, `ecs:RunTask`,
-`ecs:ExecuteCommand`, `lambda:UpdateFunctionCode`), irreversible queue operations
-(`sqs:PurgeQueue`, `sqs:DeleteQueue`), data-plane writes, and `sts:AssumeRole` - so neither role
-can be a stepping stone to the other or to the ECS runtime role.
+Direct identity administration, PassRole/AssumeRole, CloudFormation/perimeter mutations,
+code-authoring APIs and queue purge/deletion are denied. **These are not sandbox roles.**
+Diagnosis can expose credentials in objects, secrets, logs and configuration. Remediation keeps
+`StartBuild`/`RetryBuild`: buildspec/source/image overrides can execute arbitrary commands under
+existing service roles, unaffected by the human boundary. Workflow inputs and ECS service
+updates also permit delegated effects; operations are not guaranteed reversible. Read and
+approve the [retained risks and enablement checklist](docs/source/human_access_roles.rst).
+
+MFA is checked on role assumption, not downstream API calls. Both roles enforce a **one-hour**
+maximum, IAM's minimum supported ceiling. Request 1800 seconds for remediation as guidance only,
+not enforced 30-minute access. KMS decrypt remains separately off by default; enabling it may
+grant access immediately through an existing key policy's delegation to account IAM.
 
 > ### These JSON documents are illustrative, not authoritative
 >
 > They are provided for group discussion. **The deployed policy is whatever `src/parts/iam.py`
 > renders** - that is the single source of truth, and `tests/test_human_access_roles.py` asserts
-> that the action sets below match it statement for statement.
+> that the actions, resources and conditions below match it statement for statement.
 >
 > They are **not deployable as written**: `<region>` and `<account-id>` are placeholders for
 > CloudFormation's `AWS::Region` and `AWS::AccountId`, and the trust policy (which needs approved
@@ -97,10 +97,9 @@ can be a stepping stone to the other or to the ECS runtime role.
 
 ### Illustrative policy: diagnostic role (`*DevDiagnoseRole`)
 
-Read and inspect only. Retains resource-scoped Secrets Manager and S3 object reads so a developer
-can gather evidence, and denies the data-exfiltration paths a read-only role should not have
-(`sqs:ReceiveMessage`, `rds:Download*LogFile*`, `lambda:GetFunctionConfiguration`,
-`ssm:GetParameter`). `kms:Decrypt` is **not** shown because it is off by default; enabling
+Read and inspect, including sensitive Secrets Manager and S3 data. Direct SQS message,
+RDS-log, Lambda-function and SSM-parameter retrieval are denied, but other allowed reads can
+still expose configuration or credentials. `kms:Decrypt` is **not** shown because it is off by default; enabling
 `human_access.diagnose.allow_kms_decrypt` adds a `DecryptWithApplicationKeys` statement.
 
 ```json
@@ -108,13 +107,11 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "InspectServiceStateAcrossSupportedServices",
+      "Effect": "Allow",
       "Action": [
         "sts:GetCallerIdentity",
-        "ecs:DescribeClusters",
-        "ecs:DescribeServices",
-        "ecs:DescribeTasks",
         "ecs:DescribeTaskDefinition",
-        "ecs:DescribeContainerInstances",
         "ecs:ListClusters",
         "ecs:ListServices",
         "ecs:ListTasks",
@@ -132,28 +129,17 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
         "cloudwatch:GetMetricStatistics",
         "cloudwatch:ListMetrics",
         "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams",
         "logs:DescribeQueries",
-        "rds:DescribeDBInstances",
-        "rds:DescribeDBParameters",
-        "rds:DescribeDBSnapshots",
+        "logs:StopQuery",
         "rds:DescribeEvents",
-        "es:DescribeDomain",
-        "es:DescribeDomains",
         "es:ListDomainNames",
         "elasticache:DescribeCacheClusters",
         "sqs:ListQueues",
-        "cloudformation:DescribeStacks",
-        "cloudformation:DescribeStackEvents",
-        "cloudformation:DescribeStackResources",
         "cloudformation:ListStacks",
-        "cloudformation:GetTemplate",
-        "cloudformation:GetStackPolicy",
         "ecr:GetAuthorizationToken",
         "codebuild:ListProjects",
         "codebuild:ListBuilds",
         "states:ListStateMachines",
-        "states:ListExecutions",
         "lambda:ListFunctions",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
@@ -166,33 +152,183 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
         "secretsmanager:ListSecrets",
         "kms:ListAliases"
       ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        },
+        "StringEqualsIfExists": {
+          "aws:ResourceAccount": "<account-id>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectecscluster",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeClusters"
+      ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:cluster/*",
       "Condition": {
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "*",
-      "Sid": "InspectServiceStateAcrossSupportedServices"
+      }
     },
     {
+      "Sid": "Inspectecsservice",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeServices"
+      ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:service/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectecstask",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTasks"
+      ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:task/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectecscontainerinstance",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeContainerInstances"
+      ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:container-instance/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectcloudformationstack",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:GetTemplate",
+        "cloudformation:GetStackPolicy"
+      ],
+      "Resource": "arn:aws:cloudformation:<region>:<account-id>:stack/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectlogsloggroup",
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": "arn:aws:logs:<region>:<account-id>:log-group:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectesdomain",
+      "Effect": "Allow",
+      "Action": [
+        "es:DescribeDomain",
+        "es:DescribeDomains"
+      ],
+      "Resource": "arn:aws:es:<region>:<account-id>:domain/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectrdsdb",
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBInstances"
+      ],
+      "Resource": "arn:aws:rds:<region>:<account-id>:db:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectrdspg",
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBParameters"
+      ],
+      "Resource": "arn:aws:rds:<region>:<account-id>:pg:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectrdssnapshot",
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBSnapshots"
+      ],
+      "Resource": "arn:aws:rds:<region>:<account-id>:snapshot:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "InspectstatesstateMachine",
+      "Effect": "Allow",
+      "Action": [
+        "states:ListExecutions"
+      ],
+      "Resource": "arn:aws:states:<region>:<account-id>:stateMachine:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "ReadApplicationLogs",
+      "Effect": "Allow",
       "Action": [
         "logs:FilterLogEvents",
         "logs:GetLogEvents",
         "logs:GetLogGroupFields",
         "logs:GetLogRecord",
         "logs:StartQuery",
-        "logs:StopQuery",
         "logs:GetQueryResults"
       ],
-      "Effect": "Allow",
       "Resource": [
         "arn:aws:logs:<region>:<account-id>:log-group:*",
         "arn:aws:logs:<region>:<account-id>:log-group:*:log-stream:*"
-      ],
-      "Sid": "ReadApplicationLogs"
+      ]
     },
     {
+      "Sid": "InspectBucketConfiguration",
+      "Effect": "Allow",
       "Action": [
         "s3:ListBucket",
         "s3:GetBucketLocation",
@@ -205,41 +341,51 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
         "s3:GetBucketTagging",
         "s3:GetBucketCORS"
       ],
-      "Effect": "Allow",
       "Resource": "arn:aws:s3:::*",
-      "Sid": "InspectBucketConfiguration"
+      "Condition": {
+        "StringEquals": {
+          "s3:ResourceAccount": "<account-id>"
+        }
+      }
     },
     {
+      "Sid": "ReadObjects",
+      "Effect": "Allow",
       "Action": [
         "s3:GetObject",
         "s3:GetObjectVersion",
         "s3:GetObjectTagging"
       ],
-      "Effect": "Allow",
       "Resource": "arn:aws:s3:::*/*",
-      "Sid": "ReadObjects"
+      "Condition": {
+        "StringEquals": {
+          "s3:ResourceAccount": "<account-id>"
+        }
+      }
     },
     {
+      "Sid": "ReadSecrets",
+      "Effect": "Allow",
       "Action": [
         "secretsmanager:GetSecretValue",
         "secretsmanager:DescribeSecret",
         "secretsmanager:ListSecretVersionIds",
         "secretsmanager:GetResourcePolicy"
       ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:secretsmanager:<region>:<account-id>:secret:*",
-      "Sid": "ReadSecrets"
+      "Resource": "arn:aws:secretsmanager:<region>:<account-id>:secret:*"
     },
     {
+      "Sid": "InspectQueueDepth",
+      "Effect": "Allow",
       "Action": [
         "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl"
       ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:sqs:<region>:<account-id>:*",
-      "Sid": "InspectQueueDepth"
+      "Resource": "arn:aws:sqs:<region>:<account-id>:*"
     },
     {
+      "Sid": "InspectContainerImages",
+      "Effect": "Allow",
       "Action": [
         "ecr:DescribeRepositories",
         "ecr:DescribeImages",
@@ -248,50 +394,50 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
         "ecr:GetRepositoryPolicy",
         "ecr:GetLifecyclePolicy"
       ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:ecr:<region>:<account-id>:repository/*",
-      "Sid": "InspectContainerImages"
+      "Resource": "arn:aws:ecr:<region>:<account-id>:repository/*"
     },
     {
+      "Sid": "InspectBuildsAndWorkflows",
+      "Effect": "Allow",
       "Action": [
         "codebuild:BatchGetBuilds",
         "codebuild:BatchGetProjects"
       ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:codebuild:<region>:<account-id>:project/*",
-      "Sid": "InspectBuildsAndWorkflows"
+      "Resource": "arn:aws:codebuild:<region>:<account-id>:project/*"
     },
     {
+      "Sid": "InspectWorkflowExecutions",
+      "Effect": "Allow",
       "Action": [
         "states:DescribeStateMachine",
         "states:DescribeExecution",
         "states:GetExecutionHistory"
       ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:states:<region>:<account-id>:*",
-      "Sid": "InspectWorkflowExecutions"
+      "Resource": "arn:aws:states:<region>:<account-id>:*"
     },
     {
+      "Sid": "InspectKeyMetadata",
+      "Effect": "Allow",
       "Action": [
         "kms:DescribeKey",
         "kms:GetKeyRotationStatus"
       ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:kms:<region>:<account-id>:key/*",
-      "Sid": "InspectKeyMetadata"
+      "Resource": "arn:aws:kms:<region>:<account-id>:key/*"
     },
     {
+      "Sid": "InspectAccountRoleDefinitions",
+      "Effect": "Allow",
       "Action": [
         "iam:GetRole",
         "iam:GetRolePolicy",
         "iam:ListRolePolicies",
         "iam:ListAttachedRolePolicies"
       ],
-      "Effect": "Allow",
-      "Resource": "arn:aws:iam::<account-id>:role/*",
-      "Sid": "InspectOwnRoleDefinition"
+      "Resource": "arn:aws:iam::<account-id>:role/*"
     },
     {
+      "Sid": "DiagnosisIsReadOnly",
+      "Effect": "Deny",
       "Action": [
         "s3:PutObject",
         "s3:DeleteObject",
@@ -352,16 +498,10 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
         "kms:GenerateDataKeyWithoutPlaintext",
         "kms:ReEncryptFrom"
       ],
-      "Effect": "Deny",
-      "Resource": "*",
-      "Sid": "DiagnosisIsReadOnly"
+      "Resource": "*"
     },
     {
-      "Condition": {
-        "StringNotEquals": {
-          "aws:RequestedRegion": "<region>"
-        }
-      },
+      "Sid": "DenyOutsideHomeRegionExceptGlobalServices",
       "Effect": "Deny",
       "NotAction": [
         "iam:*",
@@ -376,7 +516,25 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
         "ce:*"
       ],
       "Resource": "*",
-      "Sid": "DenyOutsideHomeRegionExceptGlobalServices"
+      "Condition": {
+        "StringNotEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "DenyS3OutsideThisAccount",
+      "Effect": "Deny",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::*",
+        "arn:aws:s3:::*/*"
+      ],
+      "Condition": {
+        "StringNotEquals": {
+          "s3:ResourceAccount": "<account-id>"
+        }
+      }
     }
   ]
 }
@@ -384,22 +542,20 @@ can gather evidence, and denies the data-exfiltration paths a read-only role sho
 
 ### Illustrative policy: remediation role (`*PowerRemediateRole`)
 
-Six operational actions, each scoped to its service and each gated on region plus a live MFA
-session. Every one is reversible: restart or rescale a service, stop a stuck task, release
-in-flight queue messages, start or stop a workflow execution, and trigger a CI rebuild. Its read
-set is deliberately narrower than the diagnostic role's - no secrets, no S3, no KMS - which keeps
-CloudTrail cleanly separable into "someone was looking" and "someone was changing".
+Eight operational APIs in six groups, region-pinned after MFA-protected assumption: update a
+service, stop a task, change visibility using an existing receipt handle, start/stop a workflow,
+and start/stop/retry a build. Direct secrets, S3 and KMS reads are denied, but delegated build
+commands and workflow inputs can exercise the separately privileged execution roles.
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "ReadsNeededToTargetARemediation",
+      "Effect": "Allow",
       "Action": [
         "sts:GetCallerIdentity",
-        "ecs:DescribeClusters",
-        "ecs:DescribeServices",
-        "ecs:DescribeTasks",
         "ecs:DescribeTaskDefinition",
         "ecs:ListClusters",
         "ecs:ListServices",
@@ -410,126 +566,210 @@ CloudTrail cleanly separable into "someone was looking" and "someone was changin
         "cloudwatch:DescribeAlarms",
         "cloudwatch:GetMetricData",
         "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams",
         "sqs:ListQueues",
         "codebuild:ListProjects",
         "codebuild:ListBuilds",
         "states:ListStateMachines",
-        "states:ListExecutions",
-        "cloudformation:DescribeStacks",
         "cloudformation:ListStacks",
-        "rds:DescribeDBInstances",
-        "es:DescribeDomain",
         "es:ListDomainNames"
       ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        },
+        "StringEqualsIfExists": {
+          "aws:ResourceAccount": "<account-id>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectecscluster",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeClusters"
+      ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:cluster/*",
       "Condition": {
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "*",
-      "Sid": "ReadsNeededToTargetARemediation"
+      }
     },
     {
+      "Sid": "Inspectecsservice",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeServices"
+      ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:service/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectecstask",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTasks"
+      ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:task/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectcloudformationstack",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:DescribeStacks"
+      ],
+      "Resource": "arn:aws:cloudformation:<region>:<account-id>:stack/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectlogsloggroup",
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": "arn:aws:logs:<region>:<account-id>:log-group:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectesdomain",
+      "Effect": "Allow",
+      "Action": [
+        "es:DescribeDomain"
+      ],
+      "Resource": "arn:aws:es:<region>:<account-id>:domain/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "Inspectrdsdb",
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBInstances"
+      ],
+      "Resource": "arn:aws:rds:<region>:<account-id>:db:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "InspectstatesstateMachine",
+      "Effect": "Allow",
+      "Action": [
+        "states:ListExecutions"
+      ],
+      "Resource": "arn:aws:states:<region>:<account-id>:stateMachine:*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
+    },
+    {
+      "Sid": "RestartOrRescaleServices",
+      "Effect": "Allow",
       "Action": [
         "ecs:UpdateService"
       ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:service/*",
       "Condition": {
-        "Bool": {
-          "aws:MultiFactorAuthPresent": "true"
-        },
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "arn:aws:ecs:<region>:<account-id>:service/*",
-      "Sid": "RestartOrRescaleServices"
+      }
     },
     {
+      "Sid": "StopStuckTasks",
+      "Effect": "Allow",
       "Action": [
         "ecs:StopTask"
       ],
+      "Resource": "arn:aws:ecs:<region>:<account-id>:task/*",
       "Condition": {
-        "Bool": {
-          "aws:MultiFactorAuthPresent": "true"
-        },
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "arn:aws:ecs:<region>:<account-id>:task/*",
-      "Sid": "StopStuckTasks"
+      }
     },
     {
+      "Sid": "ReleaseInFlightQueueMessages",
+      "Effect": "Allow",
       "Action": [
         "sqs:ChangeMessageVisibility"
       ],
+      "Resource": "arn:aws:sqs:<region>:<account-id>:*",
       "Condition": {
-        "Bool": {
-          "aws:MultiFactorAuthPresent": "true"
-        },
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "arn:aws:sqs:<region>:<account-id>:*",
-      "Sid": "ReleaseInFlightQueueMessages"
+      }
     },
     {
+      "Sid": "StartWorkflowExecutions",
+      "Effect": "Allow",
       "Action": [
         "states:StartExecution"
       ],
+      "Resource": "arn:aws:states:<region>:<account-id>:stateMachine:*",
       "Condition": {
-        "Bool": {
-          "aws:MultiFactorAuthPresent": "true"
-        },
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "arn:aws:states:<region>:<account-id>:stateMachine:*",
-      "Sid": "StartWorkflowExecutions"
+      }
     },
     {
+      "Sid": "StopWorkflowExecutions",
+      "Effect": "Allow",
       "Action": [
         "states:StopExecution"
       ],
+      "Resource": "arn:aws:states:<region>:<account-id>:execution:*",
       "Condition": {
-        "Bool": {
-          "aws:MultiFactorAuthPresent": "true"
-        },
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "arn:aws:states:<region>:<account-id>:execution:*",
-      "Sid": "StopWorkflowExecutions"
+      }
     },
     {
+      "Sid": "DelegateBuildsToExistingServiceRoles",
+      "Effect": "Allow",
       "Action": [
         "codebuild:StartBuild",
         "codebuild:StopBuild",
         "codebuild:RetryBuild"
       ],
+      "Resource": "arn:aws:codebuild:<region>:<account-id>:project/*",
       "Condition": {
-        "Bool": {
-          "aws:MultiFactorAuthPresent": "true"
-        },
         "StringEquals": {
           "aws:RequestedRegion": "<region>"
         }
-      },
-      "Effect": "Allow",
-      "Resource": "arn:aws:codebuild:<region>:<account-id>:project/*",
-      "Sid": "RebuildApplicationImageViaCiOnly"
+      }
     },
     {
+      "Sid": "DenyDirectCodeDataAndIdentityOperations",
+      "Effect": "Deny",
       "Action": [
         "ecs:RegisterTaskDefinition",
         "ecs:DeregisterTaskDefinition",
@@ -577,16 +817,10 @@ CloudTrail cleanly separable into "someone was looking" and "someone was changin
         "sts:AssumeRoleWithWebIdentity",
         "sts:GetFederationToken"
       ],
-      "Effect": "Deny",
-      "Resource": "*",
-      "Sid": "RemediationCannotSupplyCodeDestroyDataOrReadIt"
+      "Resource": "*"
     },
     {
-      "Condition": {
-        "StringNotEquals": {
-          "aws:RequestedRegion": "<region>"
-        }
-      },
+      "Sid": "DenyOutsideHomeRegionExceptGlobalServices",
       "Effect": "Deny",
       "NotAction": [
         "iam:*",
@@ -601,7 +835,11 @@ CloudTrail cleanly separable into "someone was looking" and "someone was changin
         "ce:*"
       ],
       "Resource": "*",
-      "Sid": "DenyOutsideHomeRegionExceptGlobalServices"
+      "Condition": {
+        "StringNotEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,572 @@ See `docs/`.
 
 For an in-depth overview, see `docs/architecture.rst`.
 
+## Human Direct AWS Access Roles
+
+Two **optional, disabled-by-default** IAM roles let people work directly in AWS without assuming
+`*DevRole` (which is trusted by the account root and carries ten full-access managed policies):
+
+| Role | Purpose |
+|---|---|
+| `*DevDiagnoseRole` | Read-only inspection of the running system |
+| `*PowerRemediateRole` | The reversible operational actions needed to remediate those same services |
+
+They are built by `C4IAM` in `src/parts/iam.py` and live in the IAM stack. With none of the
+`human_access.*` settings present in `template.config.json` the IAM template is byte-for-byte what
+it was before, and neither role is created unless approved principal ARNs are supplied - there is
+no account-root trust fallback. See `docs/source/human_access_roles.rst` for the operator detail.
+
+### Scoping model: service-level resources, tightly constrained actions
+
+This account holds only our own resources, so these policies **do not enumerate resource
+identifiers**. Two rules apply instead:
+
+1. **Where an action supports resource-level authorization, the resource is scoped to the
+   service** - `arn:aws:ecs:<region>:<account-id>:service/*`, `arn:aws:s3:::*/*`,
+   `arn:aws:secretsmanager:<region>:<account-id>:secret:*`, and so on. That means every resource of
+   that type in this account and region, and nothing outside it.
+2. **Where an action has no resource-level authorization at all** - `ecs:Describe*`,
+   `cloudwatch:GetMetricData`, `ec2:Describe*`, `sqs:ListQueues`, `sts:GetCallerIdentity` and
+   friends - AWS accepts only `"*"`. Those live in a single clearly named read-only statement per
+   role (`InspectServiceStateAcrossSupportedServices`, `ReadsNeededToTargetARemediation`) and are
+   constrained by an `aws:RequestedRegion` condition instead.
+
+So the real constraint is **the action list**, which is fully enumerated - no `ecs:*`, no
+`s3:*`, and never `"Action": "*"` in either role. Every action is individually listed and
+justified by a supported service. Both roles also carry a permission boundary; note that a
+permission boundary is a **ceiling, not a grant** - it must open with an `Allow` or the roles could
+do nothing at all, and it does not widen either role.
+
+What both roles are prevented from doing, by their own `Deny` statements and by the boundary: IAM
+or Identity Center administration, CloudFormation mutation, network/perimeter changes, authoring or
+running new code (`ecr:PutImage`, `ecs:RegisterTaskDefinition`, `ecs:RunTask`,
+`ecs:ExecuteCommand`, `lambda:UpdateFunctionCode`), irreversible queue operations
+(`sqs:PurgeQueue`, `sqs:DeleteQueue`), data-plane writes, and `sts:AssumeRole` - so neither role
+can be a stepping stone to the other or to the ECS runtime role.
+
+> ### These JSON documents are illustrative, not authoritative
+>
+> They are provided for group discussion. **The deployed policy is whatever `src/parts/iam.py`
+> renders** - that is the single source of truth, and `tests/test_human_access_roles.py` asserts
+> that the action sets below match it statement for statement.
+>
+> They are **not deployable as written**: `<region>` and `<account-id>` are placeholders for
+> CloudFormation's `AWS::Region` and `AWS::AccountId`, and the trust policy (which needs approved
+> principal ARNs from `template.config.json`) is not shown here. The three inline policies attached
+> to each role are also merged into one document per role for readability.
+
+### Illustrative policy: diagnostic role (`*DevDiagnoseRole`)
+
+Read and inspect only. Retains resource-scoped Secrets Manager and S3 object reads so a developer
+can gather evidence, and denies the data-exfiltration paths a read-only role should not have
+(`sqs:ReceiveMessage`, `rds:Download*LogFile*`, `lambda:GetFunctionConfiguration`,
+`ssm:GetParameter`). `kms:Decrypt` is **not** shown because it is off by default; enabling
+`human_access.diagnose.allow_kms_decrypt` adds a `DecryptWithApplicationKeys` statement.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "sts:GetCallerIdentity",
+        "ecs:DescribeClusters",
+        "ecs:DescribeServices",
+        "ecs:DescribeTasks",
+        "ecs:DescribeTaskDefinition",
+        "ecs:DescribeContainerInstances",
+        "ecs:ListClusters",
+        "ecs:ListServices",
+        "ecs:ListTasks",
+        "ecs:ListTaskDefinitions",
+        "ecs:ListContainerInstances",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeRules",
+        "application-autoscaling:DescribeScalableTargets",
+        "application-autoscaling:DescribeScalingPolicies",
+        "cloudwatch:DescribeAlarms",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:DescribeQueries",
+        "rds:DescribeDBInstances",
+        "rds:DescribeDBParameters",
+        "rds:DescribeDBSnapshots",
+        "rds:DescribeEvents",
+        "es:DescribeDomain",
+        "es:DescribeDomains",
+        "es:ListDomainNames",
+        "elasticache:DescribeCacheClusters",
+        "sqs:ListQueues",
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:ListStacks",
+        "cloudformation:GetTemplate",
+        "cloudformation:GetStackPolicy",
+        "ecr:GetAuthorizationToken",
+        "codebuild:ListProjects",
+        "codebuild:ListBuilds",
+        "states:ListStateMachines",
+        "states:ListExecutions",
+        "lambda:ListFunctions",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeAvailabilityZones",
+        "servicequotas:GetServiceQuota",
+        "servicequotas:ListServiceQuotas",
+        "tag:GetResources",
+        "secretsmanager:ListSecrets",
+        "kms:ListAliases"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "InspectServiceStateAcrossSupportedServices"
+    },
+    {
+      "Action": [
+        "logs:FilterLogEvents",
+        "logs:GetLogEvents",
+        "logs:GetLogGroupFields",
+        "logs:GetLogRecord",
+        "logs:StartQuery",
+        "logs:StopQuery",
+        "logs:GetQueryResults"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:logs:<region>:<account-id>:log-group:*",
+        "arn:aws:logs:<region>:<account-id>:log-group:*:log-stream:*"
+      ],
+      "Sid": "ReadApplicationLogs"
+    },
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketPolicyStatus",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketTagging",
+        "s3:GetBucketCORS"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::*",
+      "Sid": "InspectBucketConfiguration"
+    },
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetObjectTagging"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::*/*",
+      "Sid": "ReadObjects"
+    },
+    {
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecretVersionIds",
+        "secretsmanager:GetResourcePolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:secretsmanager:<region>:<account-id>:secret:*",
+      "Sid": "ReadSecrets"
+    },
+    {
+      "Action": [
+        "sqs:GetQueueAttributes",
+        "sqs:GetQueueUrl"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:sqs:<region>:<account-id>:*",
+      "Sid": "InspectQueueDepth"
+    },
+    {
+      "Action": [
+        "ecr:DescribeRepositories",
+        "ecr:DescribeImages",
+        "ecr:ListImages",
+        "ecr:BatchGetImage",
+        "ecr:GetRepositoryPolicy",
+        "ecr:GetLifecyclePolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:ecr:<region>:<account-id>:repository/*",
+      "Sid": "InspectContainerImages"
+    },
+    {
+      "Action": [
+        "codebuild:BatchGetBuilds",
+        "codebuild:BatchGetProjects"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:codebuild:<region>:<account-id>:project/*",
+      "Sid": "InspectBuildsAndWorkflows"
+    },
+    {
+      "Action": [
+        "states:DescribeStateMachine",
+        "states:DescribeExecution",
+        "states:GetExecutionHistory"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:states:<region>:<account-id>:*",
+      "Sid": "InspectWorkflowExecutions"
+    },
+    {
+      "Action": [
+        "kms:DescribeKey",
+        "kms:GetKeyRotationStatus"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:kms:<region>:<account-id>:key/*",
+      "Sid": "InspectKeyMetadata"
+    },
+    {
+      "Action": [
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:iam::<account-id>:role/*",
+      "Sid": "InspectOwnRoleDefinition"
+    },
+    {
+      "Action": [
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:PutObjectAcl",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:RotateSecret",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath",
+        "rds:DownloadDBLogFilePortion",
+        "rds:DownloadCompleteDBLogFile",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "sqs:ReceiveMessage",
+        "sqs:SendMessage",
+        "sqs:DeleteMessage",
+        "sqs:PurgeQueue",
+        "sqs:ChangeMessageVisibility",
+        "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
+        "lambda:InvokeFunction",
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration",
+        "es:ESHttp*",
+        "ecs:UpdateService",
+        "ecs:StopTask",
+        "ecs:RunTask",
+        "ecs:StartTask",
+        "ecs:RegisterTaskDefinition",
+        "ecs:CreateService",
+        "ecs:DeleteService",
+        "ecs:ExecuteCommand",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:BatchDeleteImage",
+        "codebuild:StartBuild",
+        "codebuild:StopBuild",
+        "codebuild:RetryBuild",
+        "states:StartExecution",
+        "states:StopExecution",
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DeleteAlarms",
+        "cloudwatch:SetAlarmState",
+        "logs:PutRetentionPolicy",
+        "cloudformation:Detect*",
+        "iam:PassRole",
+        "sts:AssumeRole",
+        "sts:AssumeRoleWithSAML",
+        "sts:AssumeRoleWithWebIdentity",
+        "sts:GetFederationToken",
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:ReEncryptFrom"
+      ],
+      "Effect": "Deny",
+      "Resource": "*",
+      "Sid": "DiagnosisIsReadOnly"
+    },
+    {
+      "Condition": {
+        "StringNotEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Deny",
+      "NotAction": [
+        "iam:*",
+        "sts:*",
+        "cloudfront:*",
+        "route53:*",
+        "s3:ListAllMyBuckets",
+        "support:*",
+        "organizations:*",
+        "health:*",
+        "budgets:*",
+        "ce:*"
+      ],
+      "Resource": "*",
+      "Sid": "DenyOutsideHomeRegionExceptGlobalServices"
+    }
+  ]
+}
+```
+
+### Illustrative policy: remediation role (`*PowerRemediateRole`)
+
+Six operational actions, each scoped to its service and each gated on region plus a live MFA
+session. Every one is reversible: restart or rescale a service, stop a stuck task, release
+in-flight queue messages, start or stop a workflow execution, and trigger a CI rebuild. Its read
+set is deliberately narrower than the diagnostic role's - no secrets, no S3, no KMS - which keeps
+CloudTrail cleanly separable into "someone was looking" and "someone was changing".
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "sts:GetCallerIdentity",
+        "ecs:DescribeClusters",
+        "ecs:DescribeServices",
+        "ecs:DescribeTasks",
+        "ecs:DescribeTaskDefinition",
+        "ecs:ListClusters",
+        "ecs:ListServices",
+        "ecs:ListTasks",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "cloudwatch:DescribeAlarms",
+        "cloudwatch:GetMetricData",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "sqs:ListQueues",
+        "codebuild:ListProjects",
+        "codebuild:ListBuilds",
+        "states:ListStateMachines",
+        "states:ListExecutions",
+        "cloudformation:DescribeStacks",
+        "cloudformation:ListStacks",
+        "rds:DescribeDBInstances",
+        "es:DescribeDomain",
+        "es:ListDomainNames"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "ReadsNeededToTargetARemediation"
+    },
+    {
+      "Action": [
+        "ecs:UpdateService"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws:ecs:<region>:<account-id>:service/*",
+      "Sid": "RestartOrRescaleServices"
+    },
+    {
+      "Action": [
+        "ecs:StopTask"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws:ecs:<region>:<account-id>:task/*",
+      "Sid": "StopStuckTasks"
+    },
+    {
+      "Action": [
+        "sqs:ChangeMessageVisibility"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws:sqs:<region>:<account-id>:*",
+      "Sid": "ReleaseInFlightQueueMessages"
+    },
+    {
+      "Action": [
+        "states:StartExecution"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws:states:<region>:<account-id>:stateMachine:*",
+      "Sid": "StartWorkflowExecutions"
+    },
+    {
+      "Action": [
+        "states:StopExecution"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws:states:<region>:<account-id>:execution:*",
+      "Sid": "StopWorkflowExecutions"
+    },
+    {
+      "Action": [
+        "codebuild:StartBuild",
+        "codebuild:StopBuild",
+        "codebuild:RetryBuild"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true"
+        },
+        "StringEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Allow",
+      "Resource": "arn:aws:codebuild:<region>:<account-id>:project/*",
+      "Sid": "RebuildApplicationImageViaCiOnly"
+    },
+    {
+      "Action": [
+        "ecs:RegisterTaskDefinition",
+        "ecs:DeregisterTaskDefinition",
+        "ecs:CreateService",
+        "ecs:DeleteService",
+        "ecs:CreateCluster",
+        "ecs:DeleteCluster",
+        "ecs:RunTask",
+        "ecs:StartTask",
+        "ecs:ExecuteCommand",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:BatchDeleteImage",
+        "ecr:PutImageTagMutability",
+        "lambda:UpdateFunctionCode",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:InvokeFunction",
+        "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
+        "sqs:PurgeQueue",
+        "sqs:DeleteQueue",
+        "sqs:ReceiveMessage",
+        "sqs:SendMessage",
+        "sqs:DeleteMessage",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:ReEncryptFrom",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath",
+        "rds:DownloadDBLogFilePortion",
+        "rds:DownloadCompleteDBLogFile",
+        "es:ESHttp*",
+        "iam:PassRole",
+        "sts:AssumeRole",
+        "sts:AssumeRoleWithSAML",
+        "sts:AssumeRoleWithWebIdentity",
+        "sts:GetFederationToken"
+      ],
+      "Effect": "Deny",
+      "Resource": "*",
+      "Sid": "RemediationCannotSupplyCodeDestroyDataOrReadIt"
+    },
+    {
+      "Condition": {
+        "StringNotEquals": {
+          "aws:RequestedRegion": "<region>"
+        }
+      },
+      "Effect": "Deny",
+      "NotAction": [
+        "iam:*",
+        "sts:*",
+        "cloudfront:*",
+        "route53:*",
+        "s3:ListAllMyBuckets",
+        "support:*",
+        "organizations:*",
+        "health:*",
+        "budgets:*",
+        "ce:*"
+      ],
+      "Resource": "*",
+      "Sid": "DenyOutsideHomeRegionExceptGlobalServices"
+    }
+  ]
+}
+```
+
 ## Testing the Deployment
 
 Once the ECS Service has come online, the portal should be accessible from the URL output from the ECS Stack. At this

--- a/docs/pr99-validation.md
+++ b/docs/pr99-validation.md
@@ -1,0 +1,117 @@
+# PR 99 validation evidence
+
+## Failed-check cause
+
+The failed [run 31021769696](https://github.com/4dn-dcic/4dn-cloud-infra/actions/runs/31021769696),
+job `92359991100` (“Validate 4dn-cloud-infra stacks build successfully”), tested head
+`d1e80ab008c2e3072e54546738f64fd159123e0a`: **2 failed, 110 passed**.
+The failures were the two overwrite/no-overwrite tests in `test_setup_remaining_secrets.py`.
+
+The live source was verified before branching. Its merge base was
+`d9c9e65c799e1e24f56c6e6fdc5aeed1df9ba68e`. Although the PR API still reported that base SHA,
+current `master` was `662443ddb60067180e833b9e6630f26edef0cb73`, whose
+[run 33987067164](https://github.com/4dn-dcic/4dn-cloud-infra/actions/runs/33987067164)
+passed all 32 tests. That current base is incorporated with a merge, preserving history.
+
+### Controlled comparison
+
+Independent git archives were tested in one isolated Python 3.10.20 environment installed
+from the unchanged `poetry.lock`, using the workflow's dummy configuration. Both CI runs
+installed dcicutils 8.17.0, boto3 1.36.16 and pytest 7.4.4; the passing CI used Python 3.10.21.
+There is no lockfile/workflow change in the original PR that explains the failures.
+
+| Source | Full `tests src/tests` result |
+|---|---|
+| Exact PR head `d1e80ab` | 2 failed, 110 passed |
+| Merge base `d9c9e65` | Same 2 failed, 27 passed |
+| Current base `662443d` | 32 passed |
+| Exact PR head, replacing **only** the stale secrets test fixture with the current-base file | 112 passed |
+
+The failing file alone gave **2 failed, 1 passed** on both original head and merge base,
+and **3 passed** on current base. Conversely, restoring only the stale fixture on current
+base reproduced the same two failures. Thus role-test import order or the new IAM code is
+not necessary for the failure; the forward/reverse fixture counterfactual identifies it.
+
+- **Initiating code change:** `aee7ffc859951a459d78cc0f431f31723208699b` (2023-10-27)
+  moved `Names.application_configuration_secret` to the appconfig naming scheme but left
+  this fixture seeding `C4Datastore<Env>ApplicationConfiguration`.
+- **Masking condition:** without the workflow's required `custom/config.json` and
+  `custom/secrets.json`, full-suite collection fails before reaching these assertions.
+  Supplying those files and locked dependencies exposes the actual failure; changing
+  dependency versions or suppressing warnings is not the correction.
+- **Visible failure:** the CLI looks for `C4AppConfigCgapUnitTest`, reports that it does not
+  exist, and does not update the obsolete mocked key. Assertions see old ACCOUNT_NUMBER
+  instead of `1234567890`, and `None` instead of the printed old account number.
+
+The old PR-body claim was correct **only for the old merge base**, not current master.
+Current master already fixes the fixture via `Names.application_configuration_secret`.
+The added regression also pins the expected appconfig name and explicit CLI-name override;
+all existing overwrite/encryption/access-key assertions remain exercised.
+
+## IAM review and corrections
+
+The IAM change itself did contain defects independently of that CI failure:
+
+- The remediation session ceiling of 1800 failed local cfn-lint with **E3034** (IAM minimum
+  is 3600). Both roles now enforce one hour; 1800 is caller guidance only, as explicitly
+  accepted for this design.
+- Trust rejects root, wildcard, malformed and STS-session principals, supports concrete
+  cross-account/Identity Center roles, and checks the default 2048-character trust quota.
+  JSON-array principals survive ConfigManager's stringification rather than only working
+  through a mocked getter.
+- S3 reads now require the owning account, with explicit cross-account denies that also
+  cover bucket-policy grants to sessions. Known resource-authorized inspection actions
+  use service ARNs; wildcard inventory checks owner context when AWS supplies it.
+- Boundary mutation patterns no longer accidentally deny `DescribeVpcs`/`DescribeSubnets`.
+  Tests check wildcard deny intersections, not just exact strings in inline policies.
+- MFA remains required by default in trust. Unsupported downstream MFA checks were removed:
+  AssumeRole credentials do not carry the MFA context needed for individual API checks.
+  Logs `StopQuery` now uses its required wildcard resource rather than a log-group ARN.
+- KMS documentation accounts for existing key-policy delegation to account IAM: enabling
+  decrypt can take effect immediately. Default explicit decrypt denial is retained.
+- README policy examples match complete generated statements, including resources and
+  conditions. Local boundary references, non-exported role-name outputs, disabled-default
+  parity, explicit actions, direct PassRole/AssumeRole denies and policy quotas are tested.
+
+**Retained, explicitly accepted risk:** StartBuild and RetryBuild remain enabled without a
+new restriction architecture. Buildspec/source/image/environment overrides execute under
+existing service roles. Direct human denies/boundaries do not constrain those roles.
+Workflow inputs, ECS service updates, credential-bearing diagnostic reads, source-identity
+labels and KMS behavior are documented in the [operator guide](source/human_access_roles.rst).
+No claim of a no-arbitrary-code sandbox or universally reversible remediation is made.
+
+References: [IAM role session limits](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-iam-role.html),
+[MFA API behavior](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_configure-api-require.html),
+[CodeBuild overrides](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_StartBuild.html),
+[KMS default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html).
+
+## Supported offline validation
+
+Local test runs used fake credentials, `/dev/null` credential/config files, metadata disabled,
+and blocked outbound networking; real SDK requests were blocked for final synthesis/testing.
+No role creation/assumption, CloudFormation operation, deployment, publishing or IAM application
+was performed. In particular, `make alpha` was not used.
+
+- **142 role tests**, **4 secrets tests**, **175 full-suite tests passed**.
+- All five changed Python files pass flake8; operator reStructuredText parses cleanly.
+- **21 IAM templates** pass cfn-lint without warnings: three app kinds, six feature modes
+  (disabled, diagnosis, remediation, both, KMS, SSO), plus the three full default IAM stacks.
+- **63 templates synthesized** with dummy configuration and mocked deployed-value lookups.
+  All **45 existing-stack templates** are byte-identical to the controlled current-base
+  synthesis, including IAM disabled-default output. All templates have zero cfn-lint errors.
+- Conservative serialized inline sizes: diagnosis 9460 with KMS, remediation 6025, below
+  the aggregate 10240-character limit; boundary below 6144. Trust also has a synthesis guard.
+
+### Explicit limitations, not suppressed checks
+
+Whole-repository flake8 reports **60 unchanged diagnostics** in unrelated files (current base
+has 64; four fixture-formatting diagnostics were corrected). Broad cfn-lint reports the same
+**63 legacy warnings** on branch and current base: unused parameters, hardcoded availability
+zones, S3 ACL usage, deletion/update-replacement policy advice and an obsolete dependency.
+No lint rules or CI checks were disabled to hide these.
+
+Optional blue/green synthesis hit the same APP_DEPLOYMENT guard on branch and pristine
+current base after two fixture approaches. This is a documented synthetic-validation limit,
+not evidence warranting a repository/guard change. Foursight packaging was not attempted
+because it requires deployed exports/infrastructure. Neither optional path is represented
+as validated by the supported IAM matrix or by the unit suite.

--- a/docs/source/human_access_roles.rst
+++ b/docs/source/human_access_roles.rst
@@ -5,18 +5,48 @@ Two optional IAM roles let people work directly in AWS without assuming ``*DevRo
 (which is trusted by the account root and carries ten full-access managed policies):
 
 ``*DevDiagnoseRole``
-    Read-only diagnosis. The observability reads needed to answer "is it up, why did that
-    task die, is indexing backed up", plus **resource-scoped** Secrets Manager and S3 object
-    reads so a developer can inspect the system and bring evidence to a change request.
+    Read-only diagnosis. The read/inspection actions needed to answer "is it up, why did that
+    task die, is indexing backed up", plus Secrets Manager and S3 object reads so a developer can
+    inspect the system and bring evidence to a change request.
 
 ``*PowerRemediateRole``
-    A small set of named, reversible operational writes - restart or rescale a service, stop a
-    stuck task, release in-flight queue messages, rerun a workflow, trigger a CI rebuild.
+    The reversible operational actions needed to remediate those same services: restart or
+    rescale a service, stop a stuck task, release in-flight queue messages, start or stop a
+    workflow execution, trigger a CI rebuild.
 
-Both are built by ``C4IAM`` in ``src/parts/iam.py`` and live in the IAM stack. They share a
-permission boundary that forbids identity administration, CloudFormation mutation, network
-perimeter changes, supply-chain writes and data-plane writes regardless of what their own
-policies say.
+Both are built by ``C4IAM`` in ``src/parts/iam.py`` and live in the IAM stack. The README has
+illustrative JSON for each role, which is useful for review; ``src/parts/iam.py`` is the only
+authoritative source.
+
+Scoping model
+-------------
+
+This account holds only our own resources, so these policies **do not enumerate resource
+identifiers**. Two rules apply instead:
+
+* Where an action supports resource-level authorization, the resource is scoped to the **service** -
+  ``arn:aws:ecs:<region>:<account>:service/*``, ``arn:aws:s3:::*/*``,
+  ``arn:aws:secretsmanager:<region>:<account>:secret:*`` and so on. Every resource of that type in
+  this account and region, and nothing outside it.
+* Where an action has no resource-level authorization at all (``ecs:Describe*``,
+  ``cloudwatch:GetMetricData``, ``ec2:Describe*``, ``sqs:ListQueues``, ``sts:GetCallerIdentity``),
+  AWS accepts only ``"*"``. Those actions live in one named read-only statement per role and are
+  constrained by an ``aws:RequestedRegion`` condition instead.
+
+The constraint that carries the weight is therefore **the action list**, which is fully enumerated.
+Neither role grants ``"Action": "*"`` or a service-wide wildcard such as ``ecs:*``.
+
+Consequence worth being explicit about: because remediation is scoped at the service level, it
+reaches **every** ECS service, queue, state machine and CodeBuild project in the account -
+including the live side of a blue/green pair. The controls that bound it are the short action list
+(all reversible), the MFA-gated short session, the region pin, and the fact that the role is
+disabled by default and assumable only by enumerated principals.
+
+Both roles also carry a permission boundary. A boundary is a **ceiling, not a grant**: effective
+permissions are the intersection of the role's own policies and the boundary, so it must open with
+an ``Allow`` or the roles could do nothing. It does not widen either role; it is a backstop so that
+a future additive edit still cannot reach identity administration, CloudFormation mutation, the
+network perimeter, the image supply chain, or data-plane writes.
 
 Nothing is created by default
 -----------------------------
@@ -31,7 +61,10 @@ There is no account-root trust fallback: that is the exact weakness these roles 
 Configuration
 -------------
 
-Turn a role on, and say who may assume it. Principal lists are comma-separated::
+Because resources are scoped at the service level, there is nothing to configure per resource. The
+only settings are who may assume each role, the trust conditions, and one explicit opt-in.
+
+Turn a role on and say who may assume it. Principal lists are comma-separated::
 
     "human_access.diagnose.enabled": true,
     "human_access.diagnose.trusted_principals": "arn:aws:iam::<acct>:user/alice, arn:aws:iam::<acct>:user/bob",
@@ -42,7 +75,7 @@ Turn a role on, and say who may assume it. Principal lists are comma-separated::
 Trust conditions:
 
 ``human_access.require_mfa`` (default ``true``)
-    Asserts ``aws:MultiFactorAuthPresent`` on assume and on every remediation write. Set it to
+    Asserts ``aws:MultiFactorAuthPresent`` on assume and on every remediation action. Set it to
     ``false`` **only** in an IAM Identity Center (SSO) account, where MFA is asserted upstream at
     the identity provider and this condition key cannot be relied on. Leaving it on in an SSO
     account fails closed (the role becomes unassumable), not open.
@@ -56,84 +89,38 @@ Trust conditions:
 Session length is capped by ``MaxSessionDuration`` on the role itself - one hour for diagnosis,
 thirty minutes for remediation. There is no ``sts:DurationSeconds`` condition key.
 
-Diagnostic reads
-----------------
-
-``human_access.diagnose.buckets`` (optional)
-    Buckets whose objects may be read. Defaults to this deployment's own derived application and
-    foursight buckets. Supply an explicit list where bucket names are legacy and do not follow the
-    derived ``{env_name}-application-*`` / ``{env_name}-foursight-*`` pattern - some environments
-    have pre-orchestration names such as ``foursight-prod-envs``, and a derived list will silently
-    miss them.
-
-Secrets are scoped to this deployment's application configuration (GAC) and RDS master secret,
-using the names from ``src/names.py``. Log reads are scoped to the logging stack's log groups and
-the RDS instance's log groups; those ARNs are prefix wildcards because the log groups are created
-without an explicit ``LogGroupName`` and so get CloudFormation-generated physical names.
+The one capability opt-in:
 
 ``human_access.diagnose.allow_kms_decrypt`` (default ``false``)
-    Grants ``kms:Decrypt`` on the single key named by ``s3.encrypt_key_id`` - nothing else, and
-    never a wildcard. Needed to read objects in an SSE-KMS bucket.
+    Adds ``kms:Decrypt`` and ``kms:GetKeyPolicy`` for the diagnostic role, needed to read objects in
+    an SSE-KMS bucket. It is off by default because at service scope it reaches any key in the
+    account. Plain key metadata (``kms:DescribeKey``, ``kms:GetKeyRotationStatus``,
+    ``kms:ListAliases``) is always available, so bucket encryption stays diagnosable without it.
 
     **KMS requires dual authorization.** This setting alone grants nothing: the key policy must
     also name the role. That is a separate, out-of-band change (see ``encryption.rst`` and
     ``update-kms-policy``). Until it is made, S3 object reads on an encrypted bucket return
     ``AccessDenied``, which looks like a bug but is not.
 
-Remediation targets
--------------------
-
-Every mutating statement is driven by explicitly supplied resource ARNs. An empty list means the
-capability is simply absent - nothing falls back to a derived name, to ``ENCODED_ENV_NAME``, or to
-a wildcard. Enabling the role without any of these produces a read-only role.
-
-This is deliberate, and it is how a live environment is kept out of scope: in the 4DN account the
-blue and green halves of the deployment share one account, so scope is expressed by naming ARNs,
-not by relying on an account boundary. **Supply the non-live side's ARNs only.**
-
-::
-
-    "human_access.remediate.service_arns":        "arn:aws:ecs:us-east-1:<acct>:service/<cluster>/<service>",
-    "human_access.remediate.cluster_arns":        "arn:aws:ecs:us-east-1:<acct>:cluster/<cluster>",
-    "human_access.remediate.queue_arns":          "arn:aws:sqs:us-east-1:<acct>:<env>-indexer",
-    "human_access.remediate.state_machine_arns":  "arn:aws:states:us-east-1:<acct>:stateMachine:tibanna_unicorn",
-    "human_access.remediate.codebuild_project_arns": "arn:aws:codebuild:us-east-1:<acct>:project/<project>"
-
-``service_arns`` grants ``ecs:UpdateService``; ``cluster_arns`` grants ``ecs:StopTask`` on tasks in
-that cluster; ``queue_arns`` grants ``sqs:ChangeMessageVisibility``; ``state_machine_arns`` grants
-``states:StartExecution`` / ``StopExecution``; ``codebuild_project_arns`` grants
-``codebuild:StartBuild`` / ``StopBuild`` / ``RetryBuild``.
-
-All five settings take **full ARNs, not names**. Two of them are also used to derive a second ARN:
-the ``ecs:StopTask`` resource is derived from each cluster ARN (``:cluster/X`` becomes
-``:task/X/*``), and the ``states:StopExecution`` resource from each state machine ARN
-(``:stateMachine:X`` becomes ``:execution:X:*``). A malformed ARN therefore yields a resource that
-matches nothing - the capability fails closed rather than over-granting, but it also will not work.
-
-These ARNs cannot be derived from the templates. ECS clusters and services are created without
-``ClusterName`` / ``ServiceName``, so their physical names are CloudFormation-generated - read the
-real ARNs out of the account (``aws ecs list-services --cluster <cluster>``) rather than composing
-them by hand. Note also that if the account has not opted into the long ECS ARN format, live
-service ARNs have no cluster segment and a long-form ARN here would match nothing and fail closed.
-
-``human_access.remediate.allow_queue_purge`` (default ``false``)
-    Adds ``sqs:PurgeQueue`` on the supplied queues. This is **irreversible** - purged messages are
-    gone - so it is its own explicit choice on top of having supplied queue ARNs at all.
-
 What these roles deliberately cannot do
 ---------------------------------------
 
 Neither role can push an image (``ecr:PutImage``), register a task definition, run a task, open a
-shell in a container (``ecs:ExecuteCommand``), pass a role, mutate CloudFormation, change the
-network perimeter, administer IAM or Identity Center, write to S3 or RDS, or assume another role.
-``sts:AssumeRole`` is denied so neither can be used as a stepping stone - each privilege increase
-has to be a fresh, separately audited assume from the person's own identity.
+shell in a container (``ecs:ExecuteCommand``), update Lambda code, pass a role, mutate
+CloudFormation, change the network perimeter, administer IAM or Identity Center, write to S3 or RDS,
+or assume another role. ``sts:AssumeRole`` is denied so neither can be used as a stepping stone -
+each privilege increase has to be a fresh, separately audited assume from the person's own identity.
+
+Irreversible queue operations - ``sqs:PurgeQueue`` and ``sqs:DeleteQueue`` - are excluded from
+remediation entirely and denied both on the role and in the boundary. There is no switch to enable
+them; releasing in-flight messages with ``sqs:ChangeMessageVisibility`` is the reversible
+alternative that is granted.
 
 The diagnostic role additionally cannot read SQS message bodies, RDS log files, SSM parameters, or
 Lambda function configuration and code, all of which are data or configuration exfiltration paths.
 
 One residual risk is worth stating plainly: IAM has no condition key for the task-definition
-argument of ``ecs:UpdateService``, so a remediation holder can repoint a named service at another
+argument of ``ecs:UpdateService``, so a remediation holder can repoint a service at another
 already-registered task-definition revision. That cannot be expressed in IAM. It is bounded by
 ``ecr:PutImage`` being denied (no new image content can be authored) and by CloudTrail attribution
 under a short MFA-gated session. Alerting on ``ecs:UpdateService`` events whose ``taskDefinition``
@@ -143,6 +130,7 @@ Verifying before you rely on it
 -------------------------------
 
 ``tests/test_human_access_roles.py`` pins the disabled-by-default behaviour, the trust
-restrictions, the approved diagnostic reads and the denied privileges. Against a real account,
-``aws iam simulate-custom-policy`` on the rendered policy documents is the cheapest way to confirm
-a specific action is allowed or denied before anyone depends on it.
+restrictions, the service-level resource scope, the constrained action lists, the prohibition on
+broad administration, and the alignment of the README examples with what the template renders.
+Against a real account, ``aws iam simulate-custom-policy`` on the rendered policy documents is the
+cheapest way to confirm a specific action is allowed or denied before anyone depends on it.

--- a/docs/source/human_access_roles.rst
+++ b/docs/source/human_access_roles.rst
@@ -1,0 +1,148 @@
+Human Direct AWS Access Roles
+-----------------------------
+
+Two optional IAM roles let people work directly in AWS without assuming ``*DevRole``
+(which is trusted by the account root and carries ten full-access managed policies):
+
+``*DevDiagnoseRole``
+    Read-only diagnosis. The observability reads needed to answer "is it up, why did that
+    task die, is indexing backed up", plus **resource-scoped** Secrets Manager and S3 object
+    reads so a developer can inspect the system and bring evidence to a change request.
+
+``*PowerRemediateRole``
+    A small set of named, reversible operational writes - restart or rescale a service, stop a
+    stuck task, release in-flight queue messages, rerun a workflow, trigger a CI rebuild.
+
+Both are built by ``C4IAM`` in ``src/parts/iam.py`` and live in the IAM stack. They share a
+permission boundary that forbids identity administration, CloudFormation mutation, network
+perimeter changes, supply-chain writes and data-plane writes regardless of what their own
+policies say.
+
+Nothing is created by default
+-----------------------------
+
+With none of the ``human_access.*`` settings in ``template.config.json``, the IAM template is
+byte-for-byte what it was before - no roles, no boundary, no CloudFormation parameters or
+conditions. Enabling any of this is always deliberate.
+
+A role is also **not** created when it is enabled but no approved principal ARNs were supplied.
+There is no account-root trust fallback: that is the exact weakness these roles exist to avoid.
+
+Configuration
+-------------
+
+Turn a role on, and say who may assume it. Principal lists are comma-separated::
+
+    "human_access.diagnose.enabled": true,
+    "human_access.diagnose.trusted_principals": "arn:aws:iam::<acct>:user/alice, arn:aws:iam::<acct>:user/bob",
+
+    "human_access.remediate.enabled": true,
+    "human_access.remediate.trusted_principals": "arn:aws:iam::<acct>:user/alice"
+
+Trust conditions:
+
+``human_access.require_mfa`` (default ``true``)
+    Asserts ``aws:MultiFactorAuthPresent`` on assume and on every remediation write. Set it to
+    ``false`` **only** in an IAM Identity Center (SSO) account, where MFA is asserted upstream at
+    the identity provider and this condition key cannot be relied on. Leaving it on in an SSO
+    account fails closed (the role becomes unassumable), not open.
+
+``human_access.source_identity_pattern`` (optional)
+    A ``StringLike`` pattern for ``sts:SourceIdentity``, e.g. ``*@hms.harvard.edu``. Independent of
+    this setting, an assume with **no** source identity is always refused, so every session is
+    attributable to a person in CloudTrail. Callers must therefore pass
+    ``--source-identity <you>`` to ``aws sts assume-role``.
+
+Session length is capped by ``MaxSessionDuration`` on the role itself - one hour for diagnosis,
+thirty minutes for remediation. There is no ``sts:DurationSeconds`` condition key.
+
+Diagnostic reads
+----------------
+
+``human_access.diagnose.buckets`` (optional)
+    Buckets whose objects may be read. Defaults to this deployment's own derived application and
+    foursight buckets. Supply an explicit list where bucket names are legacy and do not follow the
+    derived ``{env_name}-application-*`` / ``{env_name}-foursight-*`` pattern - some environments
+    have pre-orchestration names such as ``foursight-prod-envs``, and a derived list will silently
+    miss them.
+
+Secrets are scoped to this deployment's application configuration (GAC) and RDS master secret,
+using the names from ``src/names.py``. Log reads are scoped to the logging stack's log groups and
+the RDS instance's log groups; those ARNs are prefix wildcards because the log groups are created
+without an explicit ``LogGroupName`` and so get CloudFormation-generated physical names.
+
+``human_access.diagnose.allow_kms_decrypt`` (default ``false``)
+    Grants ``kms:Decrypt`` on the single key named by ``s3.encrypt_key_id`` - nothing else, and
+    never a wildcard. Needed to read objects in an SSE-KMS bucket.
+
+    **KMS requires dual authorization.** This setting alone grants nothing: the key policy must
+    also name the role. That is a separate, out-of-band change (see ``encryption.rst`` and
+    ``update-kms-policy``). Until it is made, S3 object reads on an encrypted bucket return
+    ``AccessDenied``, which looks like a bug but is not.
+
+Remediation targets
+-------------------
+
+Every mutating statement is driven by explicitly supplied resource ARNs. An empty list means the
+capability is simply absent - nothing falls back to a derived name, to ``ENCODED_ENV_NAME``, or to
+a wildcard. Enabling the role without any of these produces a read-only role.
+
+This is deliberate, and it is how a live environment is kept out of scope: in the 4DN account the
+blue and green halves of the deployment share one account, so scope is expressed by naming ARNs,
+not by relying on an account boundary. **Supply the non-live side's ARNs only.**
+
+::
+
+    "human_access.remediate.service_arns":        "arn:aws:ecs:us-east-1:<acct>:service/<cluster>/<service>",
+    "human_access.remediate.cluster_arns":        "arn:aws:ecs:us-east-1:<acct>:cluster/<cluster>",
+    "human_access.remediate.queue_arns":          "arn:aws:sqs:us-east-1:<acct>:<env>-indexer",
+    "human_access.remediate.state_machine_arns":  "arn:aws:states:us-east-1:<acct>:stateMachine:tibanna_unicorn",
+    "human_access.remediate.codebuild_project_arns": "arn:aws:codebuild:us-east-1:<acct>:project/<project>"
+
+``service_arns`` grants ``ecs:UpdateService``; ``cluster_arns`` grants ``ecs:StopTask`` on tasks in
+that cluster; ``queue_arns`` grants ``sqs:ChangeMessageVisibility``; ``state_machine_arns`` grants
+``states:StartExecution`` / ``StopExecution``; ``codebuild_project_arns`` grants
+``codebuild:StartBuild`` / ``StopBuild`` / ``RetryBuild``.
+
+All five settings take **full ARNs, not names**. Two of them are also used to derive a second ARN:
+the ``ecs:StopTask`` resource is derived from each cluster ARN (``:cluster/X`` becomes
+``:task/X/*``), and the ``states:StopExecution`` resource from each state machine ARN
+(``:stateMachine:X`` becomes ``:execution:X:*``). A malformed ARN therefore yields a resource that
+matches nothing - the capability fails closed rather than over-granting, but it also will not work.
+
+These ARNs cannot be derived from the templates. ECS clusters and services are created without
+``ClusterName`` / ``ServiceName``, so their physical names are CloudFormation-generated - read the
+real ARNs out of the account (``aws ecs list-services --cluster <cluster>``) rather than composing
+them by hand. Note also that if the account has not opted into the long ECS ARN format, live
+service ARNs have no cluster segment and a long-form ARN here would match nothing and fail closed.
+
+``human_access.remediate.allow_queue_purge`` (default ``false``)
+    Adds ``sqs:PurgeQueue`` on the supplied queues. This is **irreversible** - purged messages are
+    gone - so it is its own explicit choice on top of having supplied queue ARNs at all.
+
+What these roles deliberately cannot do
+---------------------------------------
+
+Neither role can push an image (``ecr:PutImage``), register a task definition, run a task, open a
+shell in a container (``ecs:ExecuteCommand``), pass a role, mutate CloudFormation, change the
+network perimeter, administer IAM or Identity Center, write to S3 or RDS, or assume another role.
+``sts:AssumeRole`` is denied so neither can be used as a stepping stone - each privilege increase
+has to be a fresh, separately audited assume from the person's own identity.
+
+The diagnostic role additionally cannot read SQS message bodies, RDS log files, SSM parameters, or
+Lambda function configuration and code, all of which are data or configuration exfiltration paths.
+
+One residual risk is worth stating plainly: IAM has no condition key for the task-definition
+argument of ``ecs:UpdateService``, so a remediation holder can repoint a named service at another
+already-registered task-definition revision. That cannot be expressed in IAM. It is bounded by
+``ecr:PutImage`` being denied (no new image content can be authored) and by CloudTrail attribution
+under a short MFA-gated session. Alerting on ``ecs:UpdateService`` events whose ``taskDefinition``
+differs from the service's prior value is the right complementary control.
+
+Verifying before you rely on it
+-------------------------------
+
+``tests/test_human_access_roles.py`` pins the disabled-by-default behaviour, the trust
+restrictions, the approved diagnostic reads and the denied privileges. Against a real account,
+``aws iam simulate-custom-policy`` on the rendered policy documents is the cheapest way to confirm
+a specific action is allowed or denied before anyone depends on it.

--- a/docs/source/human_access_roles.rst
+++ b/docs/source/human_access_roles.rst
@@ -1,136 +1,142 @@
 Human Direct AWS Access Roles
 -----------------------------
 
-Two optional IAM roles let people work directly in AWS without assuming ``*DevRole``
-(which is trusted by the account root and carries ten full-access managed policies):
+``C4IAM`` in ``src/parts/iam.py`` optionally creates ``*DevDiagnoseRole`` and
+``*PowerRemediateRole``, separate from the unchanged, much broader ``*DevRole``.
+Both are **disabled by default**. Neither is emitted without an explicit enable flag
+and a nonempty list of approved principals. No new exports or cross-stack dependencies
+are introduced; outputs contain generated role names, not credentials.
 
-``*DevDiagnoseRole``
-    Read-only diagnosis. The read/inspection actions needed to answer "is it up, why did that
-    task die, is indexing backed up", plus Secrets Manager and S3 object reads so a developer can
-    inspect the system and bring evidence to a change request.
+This is a direct-API permission model, **not a sandbox or an information-flow boundary**.
+Review the retained delegation and credential-exposure risks below before enabling it.
 
-``*PowerRemediateRole``
-    The reversible operational actions needed to remediate those same services: restart or
-    rescale a service, stop a stuck task, release in-flight queue messages, start or stop a
-    workflow execution, trigger a CI rebuild.
+Configuration and trust
+-----------------------
 
-Both are built by ``C4IAM`` in ``src/parts/iam.py`` and live in the IAM stack. The README has
-illustrative JSON for each role, which is useful for review; ``src/parts/iam.py`` is the only
-authoritative source.
-
-Scoping model
--------------
-
-This account holds only our own resources, so these policies **do not enumerate resource
-identifiers**. Two rules apply instead:
-
-* Where an action supports resource-level authorization, the resource is scoped to the **service** -
-  ``arn:aws:ecs:<region>:<account>:service/*``, ``arn:aws:s3:::*/*``,
-  ``arn:aws:secretsmanager:<region>:<account>:secret:*`` and so on. Every resource of that type in
-  this account and region, and nothing outside it.
-* Where an action has no resource-level authorization at all (``ecs:Describe*``,
-  ``cloudwatch:GetMetricData``, ``ec2:Describe*``, ``sqs:ListQueues``, ``sts:GetCallerIdentity``),
-  AWS accepts only ``"*"``. Those actions live in one named read-only statement per role and are
-  constrained by an ``aws:RequestedRegion`` condition instead.
-
-The constraint that carries the weight is therefore **the action list**, which is fully enumerated.
-Neither role grants ``"Action": "*"`` or a service-wide wildcard such as ``ecs:*``.
-
-Consequence worth being explicit about: because remediation is scoped at the service level, it
-reaches **every** ECS service, queue, state machine and CodeBuild project in the account -
-including the live side of a blue/green pair. The controls that bound it are the short action list
-(all reversible), the MFA-gated short session, the region pin, and the fact that the role is
-disabled by default and assumable only by enumerated principals.
-
-Both roles also carry a permission boundary. A boundary is a **ceiling, not a grant**: effective
-permissions are the intersection of the role's own policies and the boundary, so it must open with
-an ``Allow`` or the roles could do nothing. It does not widen either role; it is a backstop so that
-a future additive edit still cannot reach identity administration, CloudFormation mutation, the
-network perimeter, the image supply chain, or data-plane writes.
-
-Nothing is created by default
------------------------------
-
-With none of the ``human_access.*`` settings in ``template.config.json``, the IAM template is
-byte-for-byte what it was before - no roles, no boundary, no CloudFormation parameters or
-conditions. Enabling any of this is always deliberate.
-
-A role is also **not** created when it is enabled but no approved principal ARNs were supplied.
-There is no account-root trust fallback: that is the exact weakness these roles exist to avoid.
-
-Configuration
--------------
-
-Because resources are scoped at the service level, there is nothing to configure per resource. The
-only settings are who may assume each role, the trust conditions, and one explicit opt-in.
-
-Turn a role on and say who may assume it. Principal lists are comma-separated::
+Set these in ``template.config.json`` (replace placeholders before use)::
 
     "human_access.diagnose.enabled": true,
-    "human_access.diagnose.trusted_principals": "arn:aws:iam::<acct>:user/alice, arn:aws:iam::<acct>:user/bob",
-
+    "human_access.diagnose.trusted_principals": "arn:aws:iam::<account-id>:user/alice",
     "human_access.remediate.enabled": true,
-    "human_access.remediate.trusted_principals": "arn:aws:iam::<acct>:user/alice"
+    "human_access.remediate.trusted_principals": "arn:aws:iam::<account-id>:role/ApprovedOperators"
 
-Trust conditions:
+Principal lists accept comma/newline-separated strings or JSON arrays of concrete
+commercial-AWS IAM user/role ARNs. Account IDs, root, wildcards, service principals,
+STS session ARNs and malformed entries are rejected at synthesis. Generated trust policies
+must fit IAM's default 2048-character quota; this feature does not raise quotas. Identity Center role
+paths are supported. Cross-account trust is permitted only for an explicitly named
+principal; that caller also needs authorization in its own account. The policies use
+``arn:aws`` and are not a GovCloud/China partition implementation.
 
 ``human_access.require_mfa`` (default ``true``)
-    Asserts ``aws:MultiFactorAuthPresent`` on assume and on every remediation action. Set it to
-    ``false`` **only** in an IAM Identity Center (SSO) account, where MFA is asserted upstream at
-    the identity provider and this condition key cannot be relied on. Leaving it on in an SSO
-    account fails closed (the role becomes unassumable), not open.
+    The trust policy requires MFA and ``aws:MultiFactorAuthAge < 3600`` when assuming
+    either role. **MFA is enforced at assumption, not per downstream API call**:
+    AssumeRole credentials do not carry MFA context for those checks. Adding a Bool
+    MFA condition to remediation permissions would make ordinary assumed-role calls fail.
+    Set this switch to ``false`` only when the identity provider enforces MFA upstream
+    (for example, Identity Center). This switch covers both roles and all their principals;
+    do not include callers lacking upstream MFA. Leaving it on for incompatible federation fails closed.
 
 ``human_access.source_identity_pattern`` (optional)
-    A ``StringLike`` pattern for ``sts:SourceIdentity``, e.g. ``*@hms.harvard.edu``. Independent of
-    this setting, an assume with **no** source identity is always refused, so every session is
-    attributable to a person in CloudTrail. Callers must therefore pass
-    ``--source-identity <you>`` to ``aws sts assume-role``.
+    Restricts ``sts:SourceIdentity`` with StringLike, for example ``*@hms.harvard.edu``.
+    Source identity is always required; callers need ``sts:SetSourceIdentity`` and must
+    supply or propagate it. A manually supplied label is **not verified identity** and an
+    email-pattern check does not prove ownership of that email. Correlate it with the
+    authenticated caller in CloudTrail, or enforce a trusted IdP mapping upstream.
 
-Session length is capped by ``MaxSessionDuration`` on the role itself - one hour for diagnosis,
-thirty minutes for remediation. There is no ``sts:DurationSeconds`` condition key.
+Both roles have a **one-hour enforceable ceiling** (``MaxSessionDuration=3600``), the
+minimum IAM supports. Request ``DurationSeconds=1800`` for remediation, but this is
+**not an enforced 30-minute ceiling**; a caller can request 3600. There is no
+``sts:DurationSeconds`` IAM condition key and no external session broker in this design.
 
-The one capability opt-in:
+Actions, resources and boundaries
+---------------------------------
 
-``human_access.diagnose.allow_kms_decrypt`` (default ``false``)
-    Adds ``kms:Decrypt`` and ``kms:GetKeyPolicy`` for the diagnostic role, needed to read objects in
-    an SSE-KMS bucket. It is off by default because at service scope it reaches any key in the
-    account. Plain key metadata (``kms:DescribeKey``, ``kms:GetKeyRotationStatus``,
-    ``kms:ListAliases``) is always available, so bucket encryption stays diagnosable without it.
+The action allowlists are explicit: neither role grants ``Action: *`` or ``service:*``.
+Resources are service-level, not individually enumerated. Remediation covers **every**
+ECS service/task, queue, state machine/execution and CodeBuild project in this account
+and deployment region, including production and both sides of a blue/green pair.
 
-    **KMS requires dual authorization.** This setting alone grants nothing: the key policy must
-    also name the role. That is a separate, out-of-band change (see ``encryption.rst`` and
-    ``update-kms-policy``). Until it is made, S3 object reads on an encrypted bucket return
-    ``AccessDenied``, which looks like a bug but is not.
+Resource-authorized inspection (including ECS services/tasks/clusters, stack descriptions,
+log streams, RDS instances and OpenSearch domains) uses account/region service ARNs.
+The remaining discovery/inspection groups use ``Resource: *`` with ``aws:RequestedRegion``
+and ``aws:ResourceAccount`` when AWS supplies that context. Inventory requests often do
+not supply a resource owner: a region condition alone is not an account boundary.
+These groups include, for example, list APIs, task-definition inspection, metrics,
+composite-alarm inspection and cancellation of Logs Insights queries. They must not be
+mistaken for proof that every Describe/List API is unscopable.
 
-What these roles deliberately cannot do
+S3 ARNs have no account component. S3 reads require ``s3:ResourceAccount`` to match this
+account, with explicit cross-account denies in the diagnostic policy and shared boundary.
+Consequently even a bucket policy granting a human role session access cannot authorize
+reads of another account's buckets. This also excludes AWS-owned service buckets.
+
+The permission boundary is a **ceiling, not a grant**. Its Allow-all statement enables
+intersection with the role's explicit grants; the denies block direct identity, network,
+CloudFormation, code-authoring and destructive data APIs. It is defense in depth, not an
+exhaustive denylist for all future AWS APIs. Never attach additional policies on the
+assumption that the boundary alone defines this role's complete action allowlist.
+Global-service exceptions in the region deny are not grants. Keep direct PassRole,
+AssumeRole and GetFederationToken denied; use a fresh assume from the approved human
+identity to switch roles. The original DevRole is not retired by this feature.
+
+Retained risks: approve before enabling
 ---------------------------------------
 
-Neither role can push an image (``ecr:PutImage``), register a task definition, run a task, open a
-shell in a container (``ecs:ExecuteCommand``), update Lambda code, pass a role, mutate
-CloudFormation, change the network perimeter, administer IAM or Identity Center, write to S3 or RDS,
-or assume another role. ``sts:AssumeRole`` is denied so neither can be used as a stepping stone -
-each privilege increase has to be a fresh, separately audited assume from the person's own identity.
+* **Diagnostic reads expose sensitive information.** S3 objects, Secrets Manager values,
+  application logs, CloudFormation templates, build metadata, workflow histories and
+  Lambda inventory can contain data, credentials or configuration. Denying direct
+  ``lambda:GetFunctionConfiguration`` does not remove configuration returned by
+  ``lambda:ListFunctions``. Credential material copied from a secret can be used outside
+  this role; its boundary cannot constrain the separate identity. Treat diagnosis as
+  trusted access to all readable account data, not as a low-trust support role.
+* **CodeBuild delegation is intentionally retained.** ``codebuild:StartBuild`` accepts
+  ``buildspecOverride``, source/image/environment overrides and ``sourceVersion`` under
+  the existing project service role. It can execute arbitrary build commands, publish
+  images, read secrets or mutate resources permitted to that service role, even though
+  the human is denied the corresponding direct APIs and ``iam:PassRole``. ``RetryBuild``
+  can repeat a previously overridden build. The project repository/branch is not pinned
+  against request overrides. No no-override restriction or new broker is provided here.
+* ``states:StartExecution`` accepts caller-controlled input. Existing state machines can
+  perform code execution, data writes or destructive operations under their service roles.
+  Neither the human boundary nor a direct API deny propagates to those roles. Starting
+  or stopping workflows/builds/tasks is **not guaranteed reversible**.
+* ``ecs:UpdateService`` is broader than restart/rescale: this policy does not constrain
+  its task-definition, network or other supported request fields. Existing images/task
+  definitions and service-linked roles can change what runs or its exposure. Direct
+  ``ec2`` perimeter denies are not a restriction on delegated ECS service operations.
+* Queue purge/deletion/message receipt remain denied. ``ChangeMessageVisibility`` requires
+  an already-held valid receipt handle; it cannot discover/release arbitrary in-flight
+  messages while ``ReceiveMessage`` is denied. Do not promise a general queue-unblocking API.
 
-Irreversible queue operations - ``sqs:PurgeQueue`` and ``sqs:DeleteQueue`` - are excluded from
-remediation entirely and denied both on the role and in the boundary. There is no switch to enable
-them; releasing in-flight messages with ``sqs:ChangeMessageVisibility`` is the reversible
-alternative that is granted.
+Before enabling remediation, review **all** reachable CodeBuild projects, workflow input
+contracts, ECS services, their execution roles and mutable images. Approve their delegated
+privileges, require upstream change controls, and monitor CloudTrail for overrides,
+execution inputs and ECS configuration changes. Region pins restrict requests, not all
+cross-region effects that a delegated service role might cause.
 
-The diagnostic role additionally cannot read SQS message bodies, RDS log files, SSM parameters, or
-Lambda function configuration and code, all of which are data or configuration exfiltration paths.
+KMS opt-in
+----------
 
-One residual risk is worth stating plainly: IAM has no condition key for the task-definition
-argument of ``ecs:UpdateService``, so a remediation holder can repoint a service at another
-already-registered task-definition revision. That cannot be expressed in IAM. It is bounded by
-``ecr:PutImage`` being denied (no new image content can be authored) and by CloudTrail attribution
-under a short MFA-gated session. Alerting on ``ecs:UpdateService`` events whose ``taskDefinition``
-differs from the service's prior value is the right complementary control.
+``human_access.diagnose.allow_kms_decrypt`` defaults to ``false``. Decrypt is explicitly
+denied by default; key metadata remains readable. Enabling adds ``kms:Decrypt`` and
+``kms:GetKeyPolicy`` for all keys in this account/region, allowing supported encrypted
+S3 objects **and Secrets Manager secrets** to be read when otherwise authorized.
 
-Verifying before you rely on it
--------------------------------
+KMS key policy authorization is also required, but the key policy need not explicitly
+name this role: a default account-root statement can already delegate authorization to
+IAM. **The switch may grant decrypt immediately without any key-policy change.** Inspect
+existing key policies/grants before opting in. Do not change key policies merely to make
+an expected AccessDenied disappear; this template makes no key-policy changes.
 
-``tests/test_human_access_roles.py`` pins the disabled-by-default behaviour, the trust
-restrictions, the service-level resource scope, the constrained action lists, the prohibition on
-broad administration, and the alignment of the README examples with what the template renders.
-Against a real account, ``aws iam simulate-custom-policy`` on the rendered policy documents is the
-cheapest way to confirm a specific action is allowed or denied before anyone depends on it.
+Offline verification
+--------------------
+
+``tests/test_human_access_roles.py`` and ``tests/test_human_access_regressions.py`` check
+opt-in parity, malformed trust, action/deny intersections, owner conditions, references,
+IAM quotas, session limits and full README example parity (actions, resources, conditions).
+They synthesize templates; they are not an AWS IAM simulator or evidence of deployment.
+Use the mock config from ``.github/workflows/main.yml`` and locked dependencies for tests.
+Run ``pytest tests src/tests`` and local ``cfn-lint`` on synthesized templates without AWS
+credentials/network access. **Do not use ``make alpha`` for offline validation**: it invokes
+CloudFormation validation against AWS. No infrastructure is applied by these tests.

--- a/src/constants.py
+++ b/src/constants.py
@@ -132,6 +132,54 @@ class Settings:
     CODEBUILD_DEPLOY_BRANCH = 'codebuild.build_branch'
     CODEBUILD_REPO_NAME = 'codebuild.repo_name'  # name of ECR repo
 
+    # Human direct-AWS-access role options (see C4IAM.human_diagnose_role/human_remediate_role).
+    #
+    # Every setting in this block is off or empty by default: with none of them present in
+    # template.config.json the IAM stack is byte-for-byte what it was before, so enabling any of
+    # this is always a deliberate act. Two independent roles can be turned on:
+    #
+    #   diagnose  - read-only inspection of the running system
+    #   remediate - a small set of named, reversible operational writes
+    #
+    # A role is only emitted when its enable flag is on AND its trusted-principal list is
+    # non-empty; there is deliberately no account-root trust fallback. Likewise every *mutating*
+    # statement in the remediate role is driven by an explicitly supplied resource ARN and is
+    # omitted when that ARN list is empty - nothing falls back to a derived name, to ENV_NAME, or
+    # to a wildcard. That is what keeps a live (e.g. green) environment out of scope unless it is
+    # named on purpose.
+
+    # Enablement (both default false)
+    HUMAN_ACCESS_DIAGNOSE_ENABLED = 'human_access.diagnose.enabled'
+    HUMAN_ACCESS_REMEDIATE_ENABLED = 'human_access.remediate.enabled'
+
+    # Trust: comma-separated IAM principal ARNs approved to assume each role. No default.
+    HUMAN_ACCESS_DIAGNOSE_PRINCIPALS = 'human_access.diagnose.trusted_principals'
+    HUMAN_ACCESS_REMEDIATE_PRINCIPALS = 'human_access.remediate.trusted_principals'
+
+    # Trust conditions. require_mfa defaults true; set it false only for IAM Identity Center
+    # (SSO) accounts, where aws:MultiFactorAuthPresent is asserted upstream and unreliable.
+    HUMAN_ACCESS_REQUIRE_MFA = 'human_access.require_mfa'
+    # Optional StringLike pattern for sts:SourceIdentity, e.g. '*@hms.harvard.edu'.
+    HUMAN_ACCESS_SOURCE_IDENTITY_PATTERN = 'human_access.source_identity_pattern'
+
+    # Diagnostic reads. Buckets default to this deployment's derived application/foursight
+    # buckets; supply an explicit comma-separated list for environments whose bucket names are
+    # legacy (they do not all follow the derived pattern).
+    HUMAN_ACCESS_DIAGNOSE_BUCKETS = 'human_access.diagnose.buckets'
+    # kms:Decrypt on the single configured s3.encrypt_key_id, needed to read objects in an
+    # SSE-KMS bucket. Off by default, and inert until the key policy also names the role.
+    HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT = 'human_access.diagnose.allow_kms_decrypt'
+
+    # Remediation targets - explicit ARNs, one comma-separated list per capability.
+    HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS = 'human_access.remediate.service_arns'
+    HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS = 'human_access.remediate.cluster_arns'
+    HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS = 'human_access.remediate.queue_arns'
+    HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS = 'human_access.remediate.state_machine_arns'
+    HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS = 'human_access.remediate.codebuild_project_arns'
+    # sqs:PurgeQueue is irreversible, so it is its own explicit, default-off choice on top of
+    # having supplied queue ARNs at all.
+    HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE = 'human_access.remediate.allow_queue_purge'
+
 
 # dmichaels/2022-06-06: Factored out from base.py.
 COMMON_STACK_PREFIX = "c4-"
@@ -172,6 +220,11 @@ class C4IAMBase:
     STACK_NAME_TOKEN = "iam"
     STACK_TITLE_TOKEN = "IAM"
     SHARING = 'ecosystem'
+
+    # Session length for the opt-in human direct-access roles. Diagnosis is a working session;
+    # remediation is meant to be a short, deliberate act.
+    HUMAN_ACCESS_DIAGNOSE_SESSION_DURATION = 3600   # 1 hour
+    HUMAN_ACCESS_REMEDIATE_SESSION_DURATION = 1800  # 30 minutes
 
 
 # dmichaels/2022-07-05: Factored out from sentieon.py.

--- a/src/constants.py
+++ b/src/constants.py
@@ -139,14 +139,17 @@ class Settings:
     # this is always a deliberate act. Two independent roles can be turned on:
     #
     #   diagnose  - read-only inspection of the running system
-    #   remediate - a small set of named, reversible operational writes
+    #   remediate - the reversible operational actions needed to remediate those services
     #
     # A role is only emitted when its enable flag is on AND its trusted-principal list is
-    # non-empty; there is deliberately no account-root trust fallback. Likewise every *mutating*
-    # statement in the remediate role is driven by an explicitly supplied resource ARN and is
-    # omitted when that ARN list is empty - nothing falls back to a derived name, to ENV_NAME, or
-    # to a wildcard. That is what keeps a live (e.g. green) environment out of scope unless it is
-    # named on purpose.
+    # non-empty; there is deliberately no account-root trust fallback.
+    #
+    # These policies do not enumerate resource identifiers. The account holds only our own
+    # resources, so where an action supports resource-level authorization it is scoped to the
+    # service (every ECS service, every queue, every bucket in this account and region) and the
+    # constraint that matters is the enumerated action list. Consequently there is nothing here to
+    # configure per resource - the only knobs are who may assume each role and the one explicit
+    # opt-in below.
 
     # Enablement (both default false)
     HUMAN_ACCESS_DIAGNOSE_ENABLED = 'human_access.diagnose.enabled'
@@ -162,23 +165,10 @@ class Settings:
     # Optional StringLike pattern for sts:SourceIdentity, e.g. '*@hms.harvard.edu'.
     HUMAN_ACCESS_SOURCE_IDENTITY_PATTERN = 'human_access.source_identity_pattern'
 
-    # Diagnostic reads. Buckets default to this deployment's derived application/foursight
-    # buckets; supply an explicit comma-separated list for environments whose bucket names are
-    # legacy (they do not all follow the derived pattern).
-    HUMAN_ACCESS_DIAGNOSE_BUCKETS = 'human_access.diagnose.buckets'
-    # kms:Decrypt on the single configured s3.encrypt_key_id, needed to read objects in an
-    # SSE-KMS bucket. Off by default, and inert until the key policy also names the role.
+    # kms:Decrypt (and the key-policy read) for the diagnostic role, needed to read objects in an
+    # SSE-KMS bucket. Off by default: at service scope this reaches any key in the account, and it
+    # stays inert until the key policy also names the role.
     HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT = 'human_access.diagnose.allow_kms_decrypt'
-
-    # Remediation targets - explicit ARNs, one comma-separated list per capability.
-    HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS = 'human_access.remediate.service_arns'
-    HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS = 'human_access.remediate.cluster_arns'
-    HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS = 'human_access.remediate.queue_arns'
-    HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS = 'human_access.remediate.state_machine_arns'
-    HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS = 'human_access.remediate.codebuild_project_arns'
-    # sqs:PurgeQueue is irreversible, so it is its own explicit, default-off choice on top of
-    # having supplied queue ARNs at all.
-    HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE = 'human_access.remediate.allow_queue_purge'
 
 
 # dmichaels/2022-06-06: Factored out from base.py.

--- a/src/constants.py
+++ b/src/constants.py
@@ -166,8 +166,8 @@ class Settings:
     HUMAN_ACCESS_SOURCE_IDENTITY_PATTERN = 'human_access.source_identity_pattern'
 
     # kms:Decrypt (and the key-policy read) for the diagnostic role, needed to read objects in an
-    # SSE-KMS bucket. Off by default: at service scope this reaches any key in the account, and it
-    # stays inert until the key policy also names the role.
+    # SSE-KMS bucket. Off by default: at service scope this reaches any key in the account whose
+    # key policy authorizes the role, including through delegation to account IAM policies.
     HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT = 'human_access.diagnose.allow_kms_decrypt'
 
 
@@ -211,10 +211,10 @@ class C4IAMBase:
     STACK_TITLE_TOKEN = "IAM"
     SHARING = 'ecosystem'
 
-    # Session length for the opt-in human direct-access roles. Diagnosis is a working session;
-    # remediation is meant to be a short, deliberate act.
-    HUMAN_ACCESS_DIAGNOSE_SESSION_DURATION = 3600   # 1 hour
-    HUMAN_ACCESS_REMEDIATE_SESSION_DURATION = 1800  # 30 minutes
+    # IAM MaxSessionDuration has a minimum of 3600 seconds. Both enforce a one-hour ceiling;
+    # operators should request 1800 seconds for remediation, but that is guidance, not enforcement.
+    HUMAN_ACCESS_DIAGNOSE_SESSION_DURATION = 3600
+    HUMAN_ACCESS_REMEDIATE_SESSION_DURATION = 3600
 
 
 # dmichaels/2022-07-05: Factored out from sentieon.py.

--- a/src/parts/iam.py
+++ b/src/parts/iam.py
@@ -1,4 +1,7 @@
+import ast
+import json
 import logging
+import re
 
 from awacs.aws import PolicyDocument, Statement, Action, Principal, AWSPrincipal
 from awacs.ecr import (
@@ -116,8 +119,10 @@ class C4IAM(C4IAMBase, C4Part):
         if not (diagnose_wanted or remediate_wanted):
             return template
 
-        diagnose_principals = self._human_access_list(Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS)
-        remediate_principals = self._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS)
+        diagnose_principals = (self._human_access_list(Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS)
+                               if diagnose_wanted else [])
+        remediate_principals = (self._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS)
+                                if remediate_wanted else [])
         build_diagnose = diagnose_wanted and bool(diagnose_principals)
         build_remediate = remediate_wanted and bool(remediate_principals)
         if diagnose_wanted and not build_diagnose:
@@ -586,18 +591,18 @@ class C4IAM(C4IAMBase, C4Part):
     # Scoping model. This account holds only our own resources, so these policies do not enumerate
     # resource identifiers. Where an action supports resource-level authorization it is scoped to
     # the *service* - every ECS service, every queue, every bucket in this account and region - and
-    # the real constraint is the action list, which is deliberately short and enumerated. Where an
-    # action has no resource-level authorization at all (see UNSCOPABLE_READ_SIDS) the resource is
-    # '*' and the statement is region-pinned instead. Neither role ever grants Action '*'.
+    # the real constraint is the action list, which is deliberately short and enumerated. Remaining
+    # discovery/inspection requests use '*' (see WILDCARD_READ_SIDS), with a region pin and an
+    # account restriction wherever AWS supplies resource ownership. Neither role grants Action '*'.
     #
     # These are defined independently of the ecs_*_policy() helpers above on purpose. Sharing those
     # helpers is exactly what makes dev_user_role() a superset of the ECS runtime role, and reusing
     # them here would reintroduce that coupling. dev_user_role() itself is untouched.
     # -------------------------------------------------------------------------------------------
 
-    # The only statements permitted to use Resource '*': their actions have no resource-level
-    # authorization in AWS, so there is no ARN to scope them to. Every one is read-only.
-    UNSCOPABLE_READ_SIDS = (
+    # Wildcard discovery/inspection groups. Do not infer AWS authorization semantics from the Sid:
+    # some reads support ARNs, while inventory or composite-alarm requests require '*'.
+    WILDCARD_READ_SIDS = (
         'InspectServiceStateAcrossSupportedServices',
         'ReadsNeededToTargetARemediation',
     )
@@ -618,10 +623,33 @@ class C4IAM(C4IAMBase, C4Part):
             defaulting to empty. Empty means "this capability is not granted".
         """
         value = ConfigManager.get_config_setting(setting, default='')
-        if not value or value is True:
+        if value is None or value == '' or value is False:
             return []
-        items = value if isinstance(value, list) else str(value).replace('\n', ',').split(',')
-        return [item.strip() for item in items if str(item).strip()]
+        # ConfigManager._load_config stringifies JSON values, including lists, with str().
+        # Parse only a literal list; never evaluate arbitrary config text.
+        if isinstance(value, str) and value.lstrip().startswith('['):
+            try:
+                value = ast.literal_eval(value)
+            except (ValueError, SyntaxError) as error:
+                raise ValueError(f'{setting} must contain concrete IAM user or role ARNs.') from error
+        if not isinstance(value, (str, list)):
+            raise ValueError(f'{setting} must contain concrete IAM user or role ARNs.')
+        items = value if isinstance(value, list) else value.replace('\n', ',').split(',')
+        principals = []
+        for item in items:
+            if not isinstance(item, str):
+                raise ValueError(f'{setting} must contain concrete IAM user or role ARNs.')
+            item = item.strip()
+            if not item:
+                continue
+            # Never accept root, account IDs, wildcards, service principals or STS sessions.
+            # Cross-account trust is possible, but must name a specific approved user/role.
+            if not re.fullmatch(r'arn:aws:iam::[0-9]{12}:(?:user|role)/'
+                                r'(?:[A-Za-z0-9_+=,.@-]+/)*[A-Za-z0-9_+=,.@-]+', item):
+                raise ValueError(f'{setting} must contain concrete commercial-AWS IAM user or role ARNs.')
+            if item not in principals:
+                principals.append(item)
+        return principals
 
     @staticmethod
     def _human_access_require_mfa() -> bool:
@@ -643,13 +671,24 @@ class C4IAM(C4IAMBase, C4Part):
 
     @classmethod
     def _human_access_mutation_condition(cls) -> dict:
-        """ Conditions attached to every remediation write: this region, and normally a live MFA
-            session.
+        """ Region-pin every remediation write. MFA is enforced when assuming the role, not on
+            downstream calls: AssumeRole credentials do not carry MFA context for API checks.
+            See IAM's 'Secure API access with MFA' documentation.
         """
-        condition = cls._region_pin()
-        if cls._human_access_require_mfa():
-            condition['Bool'] = {'aws:MultiFactorAuthPresent': 'true'}
-        return condition
+        return cls._region_pin()
+
+    @staticmethod
+    def human_access_s3_account_deny_statement() -> dict:
+        """ S3 ARNs have no account field. Explicitly deny other owners, including resource-policy
+            grants to a role session which could bypass an identity policy's implicit deny.
+        """
+        return {
+            'Sid': 'DenyS3OutsideThisAccount',
+            'Effect': 'Deny',
+            'Action': 's3:*',
+            'Resource': ['arn:aws:s3:::*', 'arn:aws:s3:::*/*'],
+            'Condition': {'StringNotEquals': {'s3:ResourceAccount': AccountId}},
+        }
 
     @staticmethod
     def _service_arn(service: str, suffix: str):
@@ -668,8 +707,8 @@ class C4IAM(C4IAMBase, C4Part):
         ]
 
     def human_access_trust_policy(self, principal_arns: list) -> dict:
-        """ Trust policy for a human-access role: only the enumerated principal ARNs, only with an
-            attributable session.
+        """ Trust only enumerated principals and require a source-identity audit label. Manually
+            supplied labels are not verified identities; correlate the authenticated caller.
 
             Deliberately NOT AWSPrincipal(AccountId): account-root trust in a role's trust policy
             means any identity in the account holding sts:AssumeRole can assume it, which is how
@@ -696,12 +735,12 @@ class C4IAM(C4IAMBase, C4Part):
         }
         if condition:
             allow_statement['Condition'] = condition
-        return {
+        policy = {
             'Version': '2012-10-17',
             'Statement': [
                 allow_statement,
                 {
-                    # Every session must be attributable to a person in CloudTrail.
+                    # Require a label, without mistaking a caller-supplied value for verified identity.
                     'Sid': 'DenyAssumeWithoutSourceIdentity',
                     'Effect': 'Deny',
                     'Principal': {'AWS': '*'},
@@ -710,6 +749,10 @@ class C4IAM(C4IAMBase, C4Part):
                 },
             ],
         }
+        if len(json.dumps(policy, separators=(',', ':'))) > 2048:
+            raise ValueError('Human access trust policy exceeds the default IAM 2048-character limit;'
+                             ' reduce the principal list or source-identity pattern.')
+        return policy
 
     @classmethod
     def human_access_region_deny_statement(cls) -> dict:
@@ -733,9 +776,9 @@ class C4IAM(C4IAMBase, C4Part):
             able to do nothing at all. That Allow does not widen either role - each role's own
             policies enumerate a short action list and never use Action '*'.
 
-            What this adds is a backstop: a future additive edit to either role still cannot reach
-            identity administration, CloudFormation mutation, the network perimeter, the image
-            supply chain, or data-plane writes.
+            This adds explicit direct-API backstops, not a complete future-proof allowlist or an
+            information-flow sandbox. It does not constrain separately privileged service roles
+            reached through the deliberately retained build/workflow delegation.
         """
         return ManagedPolicy(
             self.name.logical_id('HumanAccessBoundary'),
@@ -752,14 +795,14 @@ class C4IAM(C4IAMBase, C4Part):
                             'iam:Create*', 'iam:Delete*', 'iam:Update*', 'iam:Put*', 'iam:Attach*',
                             'iam:Detach*', 'iam:Add*', 'iam:Remove*', 'iam:Set*', 'iam:Tag*',
                             'iam:Untag*', 'iam:ChangePassword', 'iam:PassRole',
-                            'sso:*', 'sso-admin:*', 'sso-directory:*', 'identitystore:*',
+                            'sso:*', 'sso-directory:*', 'identitystore:*',
                             'organizations:*', 'account:*', 'aws-portal:*', 'billing:*', 'ce:*',
                             'budgets:*', 'cur:*', 'sts:GetFederationToken',
                         ],
                         'Resource': '*',
                     },
                     {
-                        'Sid': 'NeverCodeSupplyChainOrArbitraryExecution',
+                        'Sid': 'NeverDirectCodeSupplyChainOrExecution',
                         'Effect': 'Deny',
                         'Action': [
                             'ecr:PutImage', 'ecr:InitiateLayerUpload', 'ecr:UploadLayerPart',
@@ -794,9 +837,12 @@ class C4IAM(C4IAMBase, C4Part):
                             'cloudformation:CreateStackInstances',
                             'ec2:AuthorizeSecurityGroup*', 'ec2:RevokeSecurityGroup*',
                             'ec2:CreateSecurityGroup', 'ec2:DeleteSecurityGroup',
-                            'ec2:ModifySecurityGroupRules', 'ec2:*Vpc*', 'ec2:*Subnet*',
-                            'ec2:*Route*', 'ec2:*InternetGateway*', 'ec2:*NatGateway*',
-                            'ec2:*NetworkAcl*', 'ec2:RunInstances', 'ec2:TerminateInstances',
+                            # Match mutation verbs, not resource nouns: *Vpc* and *Subnet*
+                            # also denied the explicitly allowed DescribeVpcs/DescribeSubnets.
+                            'ec2:Create*', 'ec2:Delete*', 'ec2:Modify*', 'ec2:Attach*',
+                            'ec2:Detach*', 'ec2:Associate*', 'ec2:Disassociate*', 'ec2:Replace*',
+                            'ec2:Accept*', 'ec2:Reject*', 'ec2:Enable*', 'ec2:Disable*',
+                            'ec2:RunInstances', 'ec2:TerminateInstances',
                             'elasticloadbalancing:Create*', 'elasticloadbalancing:Delete*',
                             'elasticloadbalancing:Modify*', 'elasticloadbalancing:Set*',
                             'es:Create*', 'es:Delete*', 'es:Update*',
@@ -833,20 +879,61 @@ class C4IAM(C4IAMBase, C4Part):
                         'Resource': '*',
                     },
                     self.human_access_region_deny_statement(),
+                    self.human_access_s3_account_deny_statement(),
                 ],
             },
         )
 
     @classmethod
-    def human_diagnose_observability_policy(cls) -> Policy:
-        """ The read/inspection actions for the supported services whose Describe/List APIs have no
-            resource-level authorization at all. These cannot be scoped to an ARN, so they are
-            region-pinned on '*' instead. Every action here is a read.
-
-            cloudformation:Detect* is deliberately absent: drift detection starts a job, which is
-            not a read.
+    def _scope_inspection_policy(cls, policy: Policy) -> Policy:
+        """ Split known resource-authorized reads out of the discovery group. The remaining
+            inventory/inspection actions stay region-pinned; account ownership is checked when
+            provided by AWS (inventory requests often have no resource-account context).
         """
-        return Policy(
+        statement = policy.PolicyDocument['Statement'][0]
+        scoped = {
+            'ecs': {
+                'cluster/*': ['ecs:DescribeClusters'],
+                'service/*': ['ecs:DescribeServices'],
+                'task/*': ['ecs:DescribeTasks'],
+                'container-instance/*': ['ecs:DescribeContainerInstances'],
+            },
+            'cloudformation': {'stack/*': [
+                'cloudformation:DescribeStacks', 'cloudformation:DescribeStackEvents',
+                'cloudformation:DescribeStackResources', 'cloudformation:GetTemplate',
+                'cloudformation:GetStackPolicy',
+            ]},
+            'logs': {'log-group:*': ['logs:DescribeLogStreams']},
+            'es': {'domain/*': ['es:DescribeDomain', 'es:DescribeDomains']},
+            'rds': {
+                'db:*': ['rds:DescribeDBInstances'],
+                'pg:*': ['rds:DescribeDBParameters'],
+                'snapshot:*': ['rds:DescribeDBSnapshots'],
+            },
+            'states': {'stateMachine:*': ['states:ListExecutions']},
+        }
+        for service, resources in scoped.items():
+            for resource, actions in resources.items():
+                selected = [action for action in actions if action in statement['Action']]
+                if not selected:
+                    continue
+                statement['Action'] = [a for a in statement['Action'] if a not in selected]
+                policy.PolicyDocument['Statement'].append({
+                    'Sid': 'Inspect' + re.sub('[^a-zA-Z0-9]', '', service + resource),
+                    'Effect': 'Allow', 'Action': selected,
+                    'Resource': cls._service_arn(service, resource),
+                    'Condition': cls._region_pin(),
+                })
+        statement['Condition']['StringEqualsIfExists'] = {'aws:ResourceAccount': AccountId}
+        return policy
+
+    @classmethod
+    def human_diagnose_observability_policy(cls) -> Policy:
+        """ Supported inspection/discovery actions. Resource-authorized reads are separated by
+            _scope_inspection_policy; remaining wildcard requests are region-pinned.
+            cloudformation:Detect* is absent because drift detection mutates service state.
+        """
+        return cls._scope_inspection_policy(Policy(
             PolicyName='HumanDiagnoseObservabilityPolicy',
             PolicyDocument={
                 'Version': '2012-10-17',
@@ -873,7 +960,7 @@ class C4IAM(C4IAMBase, C4Part):
                         'cloudwatch:GetMetricStatistics', 'cloudwatch:ListMetrics',
                         # Log group discovery (reading the events themselves is scoped below)
                         'logs:DescribeLogGroups', 'logs:DescribeLogStreams',
-                        'logs:DescribeQueries',
+                        'logs:DescribeQueries', 'logs:StopQuery',
                         # Datastores
                         'rds:DescribeDBInstances', 'rds:DescribeDBParameters',
                         'rds:DescribeDBSnapshots', 'rds:DescribeEvents',
@@ -900,7 +987,7 @@ class C4IAM(C4IAMBase, C4Part):
                     'Condition': cls._region_pin(),
                 }],
             },
-        )
+        ))
 
     def human_diagnose_resource_read_policy(self) -> Policy:
         """ The read/inspection actions that DO support resource-level authorization, scoped to the
@@ -916,7 +1003,7 @@ class C4IAM(C4IAMBase, C4Part):
                 'Effect': 'Allow',
                 'Action': [
                     'logs:FilterLogEvents', 'logs:GetLogEvents', 'logs:GetLogGroupFields',
-                    'logs:GetLogRecord', 'logs:StartQuery', 'logs:StopQuery',
+                    'logs:GetLogRecord', 'logs:StartQuery',
                     'logs:GetQueryResults',
                 ],
                 'Resource': self._log_group_arns(),
@@ -931,12 +1018,14 @@ class C4IAM(C4IAMBase, C4Part):
                     's3:GetBucketPublicAccessBlock', 's3:GetBucketTagging', 's3:GetBucketCORS',
                 ],
                 'Resource': 'arn:aws:s3:::*',
+                'Condition': {'StringEquals': {'s3:ResourceAccount': AccountId}},
             },
             {
                 'Sid': 'ReadObjects',
                 'Effect': 'Allow',
                 'Action': ['s3:GetObject', 's3:GetObjectVersion', 's3:GetObjectTagging'],
                 'Resource': 'arn:aws:s3:::*/*',
+                'Condition': {'StringEquals': {'s3:ResourceAccount': AccountId}},
             },
             {
                 'Sid': 'ReadSecrets',
@@ -985,7 +1074,7 @@ class C4IAM(C4IAMBase, C4Part):
                 'Resource': self._service_arn('kms', 'key/*'),
             },
             {
-                'Sid': 'InspectOwnRoleDefinition',
+                'Sid': 'InspectAccountRoleDefinitions',
                 'Effect': 'Allow',
                 'Action': ['iam:GetRole', 'iam:GetRolePolicy', 'iam:ListRolePolicies',
                            'iam:ListAttachedRolePolicies'],
@@ -994,9 +1083,9 @@ class C4IAM(C4IAMBase, C4Part):
         ]
         if self._human_access_flag(Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT):
             # Off by default. Needed to read objects in an SSE-KMS bucket, and at service scope
-            # that means any key in the account - hence its own explicit switch. KMS also requires
-            # dual authorization, so this grant stays inert until the key policy names the role,
-            # which is a separate out-of-band change this template cannot make.
+            # that means any key in the account - hence its own explicit switch. Key policies may
+            # already delegate authorization to account IAM policies; enabling this can therefore
+            # grant decrypt immediately, without naming this role in a separate key-policy edit.
             statements.append({
                 'Sid': 'DecryptWithApplicationKeys',
                 'Effect': 'Allow',
@@ -1029,8 +1118,8 @@ class C4IAM(C4IAMBase, C4Part):
             # ChangeMessageVisibility is a remediation action rather than a read.
             'sqs:ReceiveMessage', 'sqs:SendMessage', 'sqs:DeleteMessage', 'sqs:PurgeQueue',
             'sqs:ChangeMessageVisibility',
-            # GetFunctionConfiguration returns environment variables and GetFunction returns a
-            # presigned code download URL; both are configuration exfiltration paths.
+            # Block direct function/configuration retrieval. This is not an information-flow
+            # guarantee: ListFunctions, logs and secrets can also expose configuration or data.
             'lambda:GetFunction', 'lambda:GetFunctionConfiguration', 'lambda:InvokeFunction',
             'lambda:UpdateFunctionCode', 'lambda:UpdateFunctionConfiguration',
             'es:ESHttp*',
@@ -1059,6 +1148,7 @@ class C4IAM(C4IAMBase, C4Part):
                     {'Sid': 'DiagnosisIsReadOnly', 'Effect': 'Deny',
                      'Action': actions, 'Resource': '*'},
                     cls.human_access_region_deny_statement(),
+                    cls.human_access_s3_account_deny_statement(),
                 ],
             },
         )
@@ -1084,15 +1174,14 @@ class C4IAM(C4IAMBase, C4Part):
 
     @classmethod
     def human_remediate_read_policy(cls) -> Policy:
-        """ The reads a power user needs to target a remediation safely - you cannot restart a
-            service you cannot find, or release in-flight messages without first seeing the
-            backlog. Same '*'-with-region-pin rationale as the diagnostic observability policy.
+        """ Reads needed to target remediation. The same resource splitting and region/account
+            conditions as the diagnostic observability policy apply.
 
             Deliberately narrower than the diagnostic role's reads: no secrets, no S3, no KMS, no
             service quotas, no tag inventory. That keeps CloudTrail cleanly separable into
             "someone was looking" and "someone was changing".
         """
-        return Policy(
+        return cls._scope_inspection_policy(Policy(
             PolicyName='HumanRemediateReadPolicy',
             PolicyDocument={
                 'Version': '2012-10-17',
@@ -1119,18 +1208,15 @@ class C4IAM(C4IAMBase, C4Part):
                     'Condition': cls._region_pin(),
                 }],
             },
-        )
+        ))
 
     @classmethod
     def human_remediate_action_policy(cls) -> Policy:
-        """ The exact operational actions needed to remediate the supported services, each scoped
-            to the service and gated on region plus (normally) a live MFA session.
-
-            Every one is reversible. Excluded on purpose: sqs:PurgeQueue and sqs:DeleteQueue
-            (irreversible - messages are gone), anything that authors or runs new code
-            (ecr:PutImage, ecs:RegisterTaskDefinition, ecs:RunTask, ecs:ExecuteCommand,
-            lambda:UpdateFunctionCode), IAM administration, and any unrelated data-plane or
-            network mutation.
+        """ Operational actions scoped to the service and region, after MFA-protected assumption.
+            Direct code-authoring APIs, IAM administration and queue deletion/purge are excluded.
+            This is NOT a reversible-only or no-code-execution sandbox: CodeBuild overrides and
+            workflow inputs can delegate code/data mutations to existing, separately privileged
+            service roles. Keep those explicitly accepted risks visible in operator documentation.
         """
         condition = cls._human_access_mutation_condition()
         return Policy(
@@ -1179,10 +1265,11 @@ class C4IAM(C4IAMBase, C4Part):
                         'Condition': condition,
                     },
                     {
-                        # Rebuild through CI - the only sanctioned way to change what runs. The
-                        # build runs under CodeBuild's own role from the pinned repo and branch,
-                        # and the human never pushes an image (ecr:PutImage is denied).
-                        'Sid': 'RebuildApplicationImageViaCiOnly',
+                        # Deliberately retained delegated execution: StartBuild accepts buildspec,
+                        # source, image and environment overrides under the project's service role.
+                        # The human boundary does NOT constrain that role. RetryBuild can repeat
+                        # an earlier overridden build. See the operator risk/enablement checklist.
+                        'Sid': 'DelegateBuildsToExistingServiceRoles',
                         'Effect': 'Allow',
                         'Action': ['codebuild:StartBuild', 'codebuild:StopBuild',
                                    'codebuild:RetryBuild'],
@@ -1195,8 +1282,8 @@ class C4IAM(C4IAMBase, C4Part):
 
     @classmethod
     def human_remediate_guardrail_policy(cls) -> Policy:
-        """ Denies that hold whether or not the boundary is attached: no way to author or run new
-            code, no irreversible queue operation, no data or secret reads, no chaining.
+        """ Direct API denies: no code-authoring API, queue deletion, secret reads or role chaining.
+            These do not constrain downstream execution under CodeBuild or workflow service roles.
         """
         return Policy(
             PolicyName='HumanRemediateGuardrailPolicy',
@@ -1204,7 +1291,7 @@ class C4IAM(C4IAMBase, C4Part):
                 'Version': '2012-10-17',
                 'Statement': [
                     {
-                        'Sid': 'RemediationCannotSupplyCodeDestroyDataOrReadIt',
+                        'Sid': 'DenyDirectCodeDataAndIdentityOperations',
                         'Effect': 'Deny',
                         'Action': [
                             'ecs:RegisterTaskDefinition', 'ecs:DeregisterTaskDefinition',

--- a/src/parts/iam.py
+++ b/src/parts/iam.py
@@ -577,18 +577,30 @@ class C4IAM(C4IAMBase, C4Part):
         )
 
     # -------------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------------------------
     # Human direct-AWS-access roles (opt-in; nothing below is built unless config enables it)
     #
-    #   human_diagnose_role()  - read-only inspection of the running system. Keeps resource-scoped
-    #       Secrets Manager and S3 object reads, so a developer can gather evidence, plus the
-    #       observability reads needed to answer "is it up, why did it die, is it backed up".
-    #   human_remediate_role() - a small set of named, reversible operational writes, each one on
-    #       an explicitly supplied resource ARN.
+    #   human_diagnose_role()  - read-only inspection of the running system.
+    #   human_remediate_role() - the operational actions needed to remediate those same services.
     #
-    # These are defined independently of the ecs_*_policy() helpers above on purpose. Sharing
-    # those helpers is exactly what makes dev_user_role() a superset of the ECS runtime role, and
-    # reusing them here would reintroduce that coupling. dev_user_role() itself is untouched.
+    # Scoping model. This account holds only our own resources, so these policies do not enumerate
+    # resource identifiers. Where an action supports resource-level authorization it is scoped to
+    # the *service* - every ECS service, every queue, every bucket in this account and region - and
+    # the real constraint is the action list, which is deliberately short and enumerated. Where an
+    # action has no resource-level authorization at all (see UNSCOPABLE_READ_SIDS) the resource is
+    # '*' and the statement is region-pinned instead. Neither role ever grants Action '*'.
+    #
+    # These are defined independently of the ecs_*_policy() helpers above on purpose. Sharing those
+    # helpers is exactly what makes dev_user_role() a superset of the ECS runtime role, and reusing
+    # them here would reintroduce that coupling. dev_user_role() itself is untouched.
     # -------------------------------------------------------------------------------------------
+
+    # The only statements permitted to use Resource '*': their actions have no resource-level
+    # authorization in AWS, so there is no ARN to scope them to. Every one is read-only.
+    UNSCOPABLE_READ_SIDS = (
+        'InspectServiceStateAcrossSupportedServices',
+        'ReadsNeededToTargetARemediation',
+    )
 
     @staticmethod
     def _human_access_flag(setting: str) -> bool:
@@ -612,11 +624,6 @@ class C4IAM(C4IAMBase, C4Part):
         return [item.strip() for item in items if str(item).strip()]
 
     @staticmethod
-    def _region_pin() -> dict:
-        """ Condition restricting a statement to the region this stack is deployed in. """
-        return {'StringEquals': {'aws:RequestedRegion': Region}}
-
-    @staticmethod
     def _human_access_require_mfa() -> bool:
         """ Whether to assert aws:MultiFactorAuthPresent. Defaults to True; set
             human_access.require_mfa to false only for IAM Identity Center (SSO) accounts, where
@@ -629,6 +636,11 @@ class C4IAM(C4IAMBase, C4Part):
             return value
         return ConfigManager.str_to_bool(str(value)) is not False
 
+    @staticmethod
+    def _region_pin() -> dict:
+        """ Condition restricting a statement to the region this stack is deployed in. """
+        return {'StringEquals': {'aws:RequestedRegion': Region}}
+
     @classmethod
     def _human_access_mutation_condition(cls) -> dict:
         """ Conditions attached to every remediation write: this region, and normally a live MFA
@@ -640,88 +652,20 @@ class C4IAM(C4IAMBase, C4Part):
         return condition
 
     @staticmethod
-    def _build_log_group_arns(prefix: str) -> list:
-        """ Log groups created by this repo have no LogGroupName, so CloudFormation generates
-            '<stack-name>-<LogicalId>-<random>' and the ARN can only be matched by prefix.
-        """
-        return [
-            Join(':', ['arn', 'aws', 'logs', Region, AccountId, 'log-group', f'{prefix}*']),
-            Join(':', ['arn', 'aws', 'logs', Region, AccountId, 'log-group', f'{prefix}*', 'log-stream', '*']),
-        ]
+    def _service_arn(service: str, suffix: str):
+        """ Builds a service-level ARN in this account and region, e.g. 'ecs' + 'service/*'. """
+        return Join(':', ['arn', 'aws', service, Region, AccountId, suffix])
 
     @staticmethod
-    def _build_kms_key_arn(key_id: str):
-        return Join(':', ['arn', 'aws', 'kms', Region, AccountId, f'key/{key_id}'])
-
-    @staticmethod
-    def _build_iam_role_arn(name_pattern: str):
-        return Join(':', ['arn', 'aws', 'iam', '', AccountId, f'role/{name_pattern}'])
-
-    @classmethod
-    def human_access_log_group_prefix(cls) -> str:
-        """ The logging stack's name, which every application log group's physical name starts
-            with. The logging part is ecosystem-shared (see C4Logging.SHARING).
+    def _log_group_arns():
+        """ Every log group in this account and region, plus their streams. Log groups here are
+            created without an explicit LogGroupName (see C4Logging.build_log_group), so their
+            physical names are CloudFormation-generated and could not be enumerated anyway.
         """
-        from .logging import C4Logging  # deferred: avoids an import cycle between IAM and logging
-        return f'{C4Logging.suggest_stack_name().stack_name}-'
-
-    @classmethod
-    def human_access_rds_log_group_arns(cls) -> list:
-        """ RDS publishes to /aws/rds/instance/<DBInstanceIdentifier>/..., where the identifier is
-            rds.name if configured, else rds-{env_name} (see C4Datastore.rds_instance).
-        """
-        env_name = ConfigManager.get_config_setting(Settings.ENV_NAME)
-        rds_name = ConfigManager.get_config_setting(Settings.RDS_NAME, default=None) or f'rds-{env_name}'
-        return cls._build_log_group_arns(f'/aws/rds/instance/{rds_name}/')
-
-    @classmethod
-    def human_access_secret_arns(cls) -> list:
-        """ The two secrets a developer needs to read to explain application behaviour: the
-            application configuration (GAC) and the RDS master secret. Names come from names.py,
-            so these are the real identifiers rather than a guessed prefix.
-        """
-        env_name = ConfigManager.get_config_setting(Settings.ENV_NAME)
         return [
-            cls.builds_secret_manager_arn(Names.application_configuration_secret(env_name)),
-            cls.builds_secret_manager_arn(Names.rds_secret_logical_id(env_name)),
+            Join(':', ['arn', 'aws', 'logs', Region, AccountId, 'log-group', '*']),
+            Join(':', ['arn', 'aws', 'logs', Region, AccountId, 'log-group', '*', 'log-stream', '*']),
         ]
-
-    @classmethod
-    def human_access_bucket_names(cls) -> list:
-        """ Buckets the diagnostic role may read objects from. Defaults to this deployment's own
-            derived application and foursight buckets; override with an explicit list where the
-            bucket names are legacy and do not follow the derived pattern (some do not).
-        """
-        configured = cls._human_access_list(Settings.HUMAN_ACCESS_DIAGNOSE_BUCKETS)
-        if configured:
-            return configured
-        templates = [
-            ConfigManager.AppBucketTemplate.BLOBS,
-            ConfigManager.AppBucketTemplate.FILES,
-            ConfigManager.AppBucketTemplate.WFOUT,
-            ConfigManager.AppBucketTemplate.SYSTEM,
-            ConfigManager.AppBucketTemplate.METADATA_BUNDLES,
-            ConfigManager.AppBucketTemplate.TIBANNA_OUTPUT,
-            ConfigManager.AppBucketTemplate.TIBANNA_CWL,
-            ConfigManager.FSBucketTemplate.ENVS,
-            ConfigManager.FSBucketTemplate.RESULTS,
-            ConfigManager.FSBucketTemplate.APPLICATION_VERSIONS,
-        ]
-        return [ConfigManager.resolve_bucket_name(template) for template in templates]
-
-    @classmethod
-    def human_access_bucket_arns(cls) -> list:
-        return [f'arn:aws:s3:::{name}' for name in cls.human_access_bucket_names()]
-
-    @classmethod
-    def human_access_object_arns(cls) -> list:
-        return [f'arn:aws:s3:::{name}/*' for name in cls.human_access_bucket_names()]
-
-    @classmethod
-    def human_access_kms_key_arns(cls) -> list:
-        """ The single configured S3 server-side-encryption key, or nothing. Never a wildcard. """
-        key_id = ConfigManager.get_config_setting(Settings.S3_ENCRYPT_KEY_ID, default=None)
-        return [cls._build_kms_key_arn(key_id)] if key_id else []
 
     def human_access_trust_policy(self, principal_arns: list) -> dict:
         """ Trust policy for a human-access role: only the enumerated principal ARNs, only with an
@@ -729,7 +673,8 @@ class C4IAM(C4IAMBase, C4Part):
 
             Deliberately NOT AWSPrincipal(AccountId): account-root trust in a role's trust policy
             means any identity in the account holding sts:AssumeRole can assume it, which is how
-            dev_user_role() is reachable today.
+            dev_user_role() is reachable today. This is the one place identifiers are still
+            enumerated, because a trust policy is about people rather than resources.
 
             Note on session length: MaxSessionDuration on the role is the control, not a condition
             key. There is no sts:DurationSeconds condition key, and asserting a non-existent key
@@ -783,177 +728,173 @@ class C4IAM(C4IAMBase, C4Part):
     def human_access_boundary_policy(self) -> ManagedPolicy:
         """ Permission boundary shared by both human-access roles.
 
-            This is the backstop that keeps a future additive edit to either role from quietly
-            granting identity administration, supply-chain writes, or data-plane writes. It is not
-            a substitute for the Deny statements on the roles themselves: a boundary caps the
-            role's own effective permissions and is neither inherited nor applied to
-            resource-based policies.
+            A boundary is a ceiling, not a grant: effective permissions are the intersection of the
+            role's own policies and this one, so it must open with an Allow or the roles would be
+            able to do nothing at all. That Allow does not widen either role - each role's own
+            policies enumerate a short action list and never use Action '*'.
 
-            Where the roles are meant to have a narrow read (S3 objects, the two application
-            secrets, the one encryption key), the boundary denies the action everywhere *except*
-            those resources via NotResource, rather than dropping the deny altogether.
+            What this adds is a backstop: a future additive edit to either role still cannot reach
+            identity administration, CloudFormation mutation, the network perimeter, the image
+            supply chain, or data-plane writes.
         """
-        statements = [
-            {'Sid': 'AllowWhatIsNotExplicitlyForbidden', 'Effect': 'Allow',
-             'Action': '*', 'Resource': '*'},
-            {
-                'Sid': 'NeverIdentityOrgOrBillingAdministration',
-                'Effect': 'Deny',
-                'Action': [
-                    'iam:Create*', 'iam:Delete*', 'iam:Update*', 'iam:Put*', 'iam:Attach*',
-                    'iam:Detach*', 'iam:Add*', 'iam:Remove*', 'iam:Set*', 'iam:Tag*',
-                    'iam:Untag*', 'iam:ChangePassword', 'iam:PassRole',
-                    'sso:*', 'sso-admin:*', 'sso-directory:*', 'identitystore:*',
-                    'organizations:*', 'account:*', 'aws-portal:*', 'billing:*', 'ce:*',
-                    'budgets:*', 'cur:*', 'sts:GetFederationToken',
-                ],
-                'Resource': '*',
-            },
-            {
-                'Sid': 'NeverCodeSupplyChainOrArbitraryExecution',
-                'Effect': 'Deny',
-                'Action': [
-                    'ecr:PutImage', 'ecr:InitiateLayerUpload', 'ecr:UploadLayerPart',
-                    'ecr:CompleteLayerUpload', 'ecr:BatchDeleteImage', 'ecr:DeleteRepository',
-                    'ecr:SetRepositoryPolicy', 'ecr:PutImageTagMutability',
-                    'ecs:RegisterTaskDefinition', 'ecs:DeregisterTaskDefinition',
-                    'ecs:CreateService', 'ecs:DeleteService', 'ecs:CreateCluster',
-                    'ecs:DeleteCluster', 'ecs:RunTask', 'ecs:StartTask', 'ecs:ExecuteCommand',
-                    'lambda:CreateFunction', 'lambda:DeleteFunction', 'lambda:UpdateFunctionCode',
-                    'lambda:UpdateFunctionConfiguration', 'lambda:InvokeFunction',
-                    'lambda:AddPermission', 'lambda:AddLayerVersionPermission',
-                    'codebuild:CreateProject', 'codebuild:UpdateProject',
-                    'codebuild:DeleteProject', 'codebuild:UpdateProjectVisibility',
-                    'states:CreateStateMachine', 'states:UpdateStateMachine',
-                    'states:DeleteStateMachine',
-                    'ssm:SendCommand', 'ssm:StartSession',
-                ],
-                'Resource': '*',
-            },
-            {
-                'Sid': 'NeverInfrastructureOrPerimeterMutation',
-                'Effect': 'Deny',
-                'Action': [
-                    'cloudformation:CreateStack', 'cloudformation:UpdateStack',
-                    'cloudformation:DeleteStack', 'cloudformation:CreateChangeSet',
-                    'cloudformation:ExecuteChangeSet', 'cloudformation:SetStackPolicy',
-                    'cloudformation:UpdateTerminationProtection', 'cloudformation:CreateStackSet',
-                    'cloudformation:UpdateStackSet', 'cloudformation:CreateStackInstances',
-                    'ec2:AuthorizeSecurityGroup*', 'ec2:RevokeSecurityGroup*',
-                    'ec2:CreateSecurityGroup', 'ec2:DeleteSecurityGroup',
-                    'ec2:ModifySecurityGroupRules', 'ec2:*Vpc*', 'ec2:*Subnet*', 'ec2:*Route*',
-                    'ec2:*InternetGateway*', 'ec2:*NatGateway*', 'ec2:*NetworkAcl*',
-                    'ec2:RunInstances', 'ec2:TerminateInstances',
-                    'elasticloadbalancing:Create*', 'elasticloadbalancing:Delete*',
-                    'elasticloadbalancing:Modify*', 'elasticloadbalancing:Set*',
-                    'es:Create*', 'es:Delete*', 'es:Update*',
-                    'rds:Create*', 'rds:Delete*', 'rds:Modify*', 'rds:Restore*', 'rds:Reboot*',
-                    'rds:Stop*', 'rds:Start*', 'rds:Promote*', 'rds:Copy*',
-                    'elasticache:Delete*', 'elasticache:Modify*',
-                    'cloudtrail:StopLogging', 'cloudtrail:DeleteTrail', 'cloudtrail:UpdateTrail',
-                    'cloudtrail:PutEventSelectors', 'config:DeleteConfigRule',
-                    'config:StopConfigurationRecorder', 'guardduty:DeleteDetector',
-                    'guardduty:UpdateDetector',
-                    'logs:DeleteLogGroup', 'logs:DeleteLogStream',
-                ],
-                'Resource': '*',
-            },
-            {
-                'Sid': 'NeverDataPlaneWrites',
-                'Effect': 'Deny',
-                'Action': [
-                    's3:PutObject*', 's3:DeleteObject*', 's3:DeleteBucket', 's3:PutBucket*',
-                    's3:PutEncryptionConfiguration', 's3:PutLifecycleConfiguration',
-                    's3:PutReplicationConfiguration',
-                    'secretsmanager:PutSecretValue', 'secretsmanager:UpdateSecret',
-                    'secretsmanager:DeleteSecret', 'secretsmanager:RotateSecret',
-                    'secretsmanager:PutResourcePolicy', 'secretsmanager:DeleteResourcePolicy',
-                    'kms:PutKeyPolicy', 'kms:ScheduleKeyDeletion', 'kms:DisableKey',
-                    'kms:CreateGrant', 'kms:RetireGrant', 'kms:RevokeGrant',
-                    'ssm:PutParameter', 'ssm:DeleteParameter',
-                    'dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem',
-                    'es:ESHttpPost', 'es:ESHttpPut', 'es:ESHttpDelete', 'es:ESHttpPatch',
-                ],
-                'Resource': '*',
-            },
-        ]
-        # Reads the roles are meant to have, denied everywhere but on those exact resources.
-        statements.append(self._boundary_scoped_read_deny(
-            'BoundS3ObjectReadsToApplicationBuckets',
-            ['s3:GetObject', 's3:GetObjectVersion', 's3:GetObjectTagging', 's3:GetObjectTorrent'],
-            self.human_access_object_arns()))
-        statements.append(self._boundary_scoped_read_deny(
-            'BoundSecretReadsToApplicationSecrets',
-            ['secretsmanager:GetSecretValue'],
-            self.human_access_secret_arns()))
-        statements.append(self._boundary_scoped_read_deny(
-            'BoundKmsUseToConfiguredEncryptionKey',
-            ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:GenerateDataKeyWithoutPlaintext',
-             'kms:ReEncryptFrom'],
-            self.human_access_kms_key_arns()))
-        statements.append(self.human_access_region_deny_statement())
         return ManagedPolicy(
             self.name.logical_id('HumanAccessBoundary'),
-            Description='Permission boundary for the opt-in human direct-access roles.',
-            PolicyDocument={'Version': '2012-10-17', 'Statement': statements},
+            Description='Permission boundary (ceiling, not a grant) for the opt-in human'
+                        ' direct-access roles.',
+            PolicyDocument={
+                'Version': '2012-10-17',
+                'Statement': [
+                    {'Sid': 'CeilingOnly', 'Effect': 'Allow', 'Action': '*', 'Resource': '*'},
+                    {
+                        'Sid': 'NeverIdentityOrgOrBillingAdministration',
+                        'Effect': 'Deny',
+                        'Action': [
+                            'iam:Create*', 'iam:Delete*', 'iam:Update*', 'iam:Put*', 'iam:Attach*',
+                            'iam:Detach*', 'iam:Add*', 'iam:Remove*', 'iam:Set*', 'iam:Tag*',
+                            'iam:Untag*', 'iam:ChangePassword', 'iam:PassRole',
+                            'sso:*', 'sso-admin:*', 'sso-directory:*', 'identitystore:*',
+                            'organizations:*', 'account:*', 'aws-portal:*', 'billing:*', 'ce:*',
+                            'budgets:*', 'cur:*', 'sts:GetFederationToken',
+                        ],
+                        'Resource': '*',
+                    },
+                    {
+                        'Sid': 'NeverCodeSupplyChainOrArbitraryExecution',
+                        'Effect': 'Deny',
+                        'Action': [
+                            'ecr:PutImage', 'ecr:InitiateLayerUpload', 'ecr:UploadLayerPart',
+                            'ecr:CompleteLayerUpload', 'ecr:BatchDeleteImage',
+                            'ecr:DeleteRepository', 'ecr:SetRepositoryPolicy',
+                            'ecr:PutImageTagMutability',
+                            'ecs:RegisterTaskDefinition', 'ecs:DeregisterTaskDefinition',
+                            'ecs:CreateService', 'ecs:DeleteService', 'ecs:CreateCluster',
+                            'ecs:DeleteCluster', 'ecs:RunTask', 'ecs:StartTask',
+                            'ecs:ExecuteCommand',
+                            'lambda:CreateFunction', 'lambda:DeleteFunction',
+                            'lambda:UpdateFunctionCode', 'lambda:UpdateFunctionConfiguration',
+                            'lambda:InvokeFunction', 'lambda:AddPermission',
+                            'lambda:AddLayerVersionPermission',
+                            'codebuild:CreateProject', 'codebuild:UpdateProject',
+                            'codebuild:DeleteProject', 'codebuild:UpdateProjectVisibility',
+                            'states:CreateStateMachine', 'states:UpdateStateMachine',
+                            'states:DeleteStateMachine',
+                            'ssm:SendCommand', 'ssm:StartSession',
+                        ],
+                        'Resource': '*',
+                    },
+                    {
+                        'Sid': 'NeverInfrastructureOrPerimeterMutation',
+                        'Effect': 'Deny',
+                        'Action': [
+                            'cloudformation:CreateStack', 'cloudformation:UpdateStack',
+                            'cloudformation:DeleteStack', 'cloudformation:CreateChangeSet',
+                            'cloudformation:ExecuteChangeSet', 'cloudformation:SetStackPolicy',
+                            'cloudformation:UpdateTerminationProtection',
+                            'cloudformation:CreateStackSet', 'cloudformation:UpdateStackSet',
+                            'cloudformation:CreateStackInstances',
+                            'ec2:AuthorizeSecurityGroup*', 'ec2:RevokeSecurityGroup*',
+                            'ec2:CreateSecurityGroup', 'ec2:DeleteSecurityGroup',
+                            'ec2:ModifySecurityGroupRules', 'ec2:*Vpc*', 'ec2:*Subnet*',
+                            'ec2:*Route*', 'ec2:*InternetGateway*', 'ec2:*NatGateway*',
+                            'ec2:*NetworkAcl*', 'ec2:RunInstances', 'ec2:TerminateInstances',
+                            'elasticloadbalancing:Create*', 'elasticloadbalancing:Delete*',
+                            'elasticloadbalancing:Modify*', 'elasticloadbalancing:Set*',
+                            'es:Create*', 'es:Delete*', 'es:Update*',
+                            'rds:Create*', 'rds:Delete*', 'rds:Modify*', 'rds:Restore*',
+                            'rds:Reboot*', 'rds:Stop*', 'rds:Start*', 'rds:Promote*', 'rds:Copy*',
+                            'elasticache:Delete*', 'elasticache:Modify*',
+                            'cloudtrail:StopLogging', 'cloudtrail:DeleteTrail',
+                            'cloudtrail:UpdateTrail', 'cloudtrail:PutEventSelectors',
+                            'config:DeleteConfigRule', 'config:StopConfigurationRecorder',
+                            'guardduty:DeleteDetector', 'guardduty:UpdateDetector',
+                            'logs:DeleteLogGroup', 'logs:DeleteLogStream',
+                        ],
+                        'Resource': '*',
+                    },
+                    {
+                        'Sid': 'NeverDataPlaneWritesOrIrreversibleOperations',
+                        'Effect': 'Deny',
+                        'Action': [
+                            's3:PutObject*', 's3:DeleteObject*', 's3:DeleteBucket',
+                            's3:PutBucket*', 's3:PutEncryptionConfiguration',
+                            's3:PutLifecycleConfiguration', 's3:PutReplicationConfiguration',
+                            'secretsmanager:PutSecretValue', 'secretsmanager:UpdateSecret',
+                            'secretsmanager:DeleteSecret', 'secretsmanager:RotateSecret',
+                            'secretsmanager:PutResourcePolicy',
+                            'secretsmanager:DeleteResourcePolicy',
+                            'kms:PutKeyPolicy', 'kms:ScheduleKeyDeletion', 'kms:DisableKey',
+                            'kms:CreateGrant', 'kms:RetireGrant', 'kms:RevokeGrant',
+                            'ssm:PutParameter', 'ssm:DeleteParameter',
+                            'dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem',
+                            'es:ESHttpPost', 'es:ESHttpPut', 'es:ESHttpDelete', 'es:ESHttpPatch',
+                            # Irreversible, and therefore excluded from remediation entirely.
+                            'sqs:PurgeQueue', 'sqs:DeleteQueue',
+                        ],
+                        'Resource': '*',
+                    },
+                    self.human_access_region_deny_statement(),
+                ],
+            },
         )
-
-    @staticmethod
-    def _boundary_scoped_read_deny(sid: str, actions: list, allowed_resources: list) -> dict:
-        """ Deny these actions everywhere except on allowed_resources; if there is nothing to
-            carve out, deny them outright.
-        """
-        statement = {'Sid': sid, 'Effect': 'Deny', 'Action': actions}
-        if allowed_resources:
-            statement['NotResource'] = allowed_resources
-        else:
-            statement['Resource'] = '*'
-        return statement
 
     @classmethod
     def human_diagnose_observability_policy(cls) -> Policy:
-        """ The service-specific read APIs needed to inspect a running deployment. Almost all of
-            these Describe/List/Get APIs have no resource-level authorization at all, so they are
-            on '*' and constrained by region instead.
+        """ The read/inspection actions for the supported services whose Describe/List APIs have no
+            resource-level authorization at all. These cannot be scoped to an ARN, so they are
+            region-pinned on '*' instead. Every action here is a read.
 
             cloudformation:Detect* is deliberately absent: drift detection starts a job, which is
-            not a read, and it is not needed to inspect a service.
+            not a read.
         """
         return Policy(
             PolicyName='HumanDiagnoseObservabilityPolicy',
             PolicyDocument={
                 'Version': '2012-10-17',
                 'Statement': [{
-                    'Sid': 'RegionPinnedServiceStateReads',
+                    'Sid': 'InspectServiceStateAcrossSupportedServices',
                     'Effect': 'Allow',
                     'Action': [
                         'sts:GetCallerIdentity',
-                        'ecs:Describe*', 'ecs:List*',
-                        'elasticloadbalancing:Describe*',
-                        'application-autoscaling:Describe*',
-                        'cloudwatch:Describe*', 'cloudwatch:Get*', 'cloudwatch:List*',
-                        'logs:Describe*', 'logs:List*',
-                        'rds:Describe*', 'rds:ListTagsForResource',
-                        'es:Describe*', 'es:List*', 'es:Get*',
-                        'sqs:GetQueueAttributes', 'sqs:GetQueueUrl', 'sqs:ListQueues',
-                        'elasticache:Describe*', 'elasticache:List*',
-                        'cloudformation:Describe*', 'cloudformation:List*', 'cloudformation:Get*',
-                        'ecr:Describe*', 'ecr:List*', 'ecr:GetLifecyclePolicy',
-                        'ecr:GetRepositoryPolicy', 'ecr:BatchGetImage',
+                        # ECS - is the portal up, how many tasks, why did one die
+                        'ecs:DescribeClusters', 'ecs:DescribeServices', 'ecs:DescribeTasks',
+                        'ecs:DescribeTaskDefinition', 'ecs:DescribeContainerInstances',
+                        'ecs:ListClusters', 'ecs:ListServices', 'ecs:ListTasks',
+                        'ecs:ListTaskDefinitions', 'ecs:ListContainerInstances',
+                        # Load balancing - are the target groups healthy
+                        'elasticloadbalancing:DescribeLoadBalancers',
+                        'elasticloadbalancing:DescribeTargetGroups',
+                        'elasticloadbalancing:DescribeTargetHealth',
+                        'elasticloadbalancing:DescribeListeners',
+                        'elasticloadbalancing:DescribeRules',
+                        'application-autoscaling:DescribeScalableTargets',
+                        'application-autoscaling:DescribeScalingPolicies',
+                        # Metrics and alarms - saturation, cluster health
+                        'cloudwatch:DescribeAlarms', 'cloudwatch:GetMetricData',
+                        'cloudwatch:GetMetricStatistics', 'cloudwatch:ListMetrics',
+                        # Log group discovery (reading the events themselves is scoped below)
+                        'logs:DescribeLogGroups', 'logs:DescribeLogStreams',
+                        'logs:DescribeQueries',
+                        # Datastores
+                        'rds:DescribeDBInstances', 'rds:DescribeDBParameters',
+                        'rds:DescribeDBSnapshots', 'rds:DescribeEvents',
+                        'es:DescribeDomain', 'es:DescribeDomains', 'es:ListDomainNames',
+                        'elasticache:DescribeCacheClusters',
+                        'sqs:ListQueues',
+                        # Deployment provenance - which image is running, did the deploy work
+                        'cloudformation:DescribeStacks', 'cloudformation:DescribeStackEvents',
+                        'cloudformation:DescribeStackResources', 'cloudformation:ListStacks',
+                        'cloudformation:GetTemplate', 'cloudformation:GetStackPolicy',
                         'ecr:GetAuthorizationToken',
-                        'codebuild:BatchGet*', 'codebuild:List*',
-                        'states:Describe*', 'states:List*', 'states:GetExecutionHistory',
-                        'lambda:GetPolicy', 'lambda:GetAlias', 'lambda:List*',
-                        'ec2:Describe*',
-                        'servicequotas:Get*', 'servicequotas:List*',
-                        'tag:GetResources', 'tag:GetTagKeys', 'tag:GetTagValues',
+                        'codebuild:ListProjects', 'codebuild:ListBuilds',
+                        'states:ListStateMachines', 'states:ListExecutions',
+                        'lambda:ListFunctions',
+                        'ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets', 'ec2:DescribeVpcs',
+                        'ec2:DescribeNetworkInterfaces', 'ec2:DescribeAvailabilityZones',
+                        'servicequotas:GetServiceQuota', 'servicequotas:ListServiceQuotas',
+                        'tag:GetResources',
                         'secretsmanager:ListSecrets',
-                        # Key metadata only - no key material and no ciphertext access. Needed to
-                        # answer "is this bucket encrypted, and with which key": the key ARN comes
-                        # from s3:GetEncryptionConfiguration, so it cannot be scoped in advance,
-                        # and buckets may use AWS-managed keys that no config setting names. The
-                        # more revealing kms:GetKeyPolicy stays scoped to the configured key below.
-                        'kms:DescribeKey', 'kms:GetKeyRotationStatus', 'kms:ListAliases',
+                        # Key metadata only - no key material, no ciphertext, no key policy.
+                        'kms:ListAliases',
                     ],
                     'Resource': '*',
                     'Condition': cls._region_pin(),
@@ -962,27 +903,26 @@ class C4IAM(C4IAMBase, C4Part):
         )
 
     def human_diagnose_resource_read_policy(self) -> Policy:
-        """ The resource-scoped half of diagnosis: application logs, the application buckets, the
-            two application secrets, encryption-key metadata, and this role's own definition.
+        """ The read/inspection actions that DO support resource-level authorization, scoped to the
+            service rather than to enumerated identifiers.
 
-            Secrets Manager and S3 object reads are retained here on purpose - a developer is
-            expected to inspect the system and bring evidence - but only on the specific secrets
-            and buckets this deployment owns, never on '*'.
+            Secrets Manager and S3 object reads are retained on purpose - a developer is expected
+            to inspect the system and bring evidence - and are scoped to this account's secrets and
+            buckets. The action lists stay short: reads only, no writes anywhere.
         """
         statements = [
             {
-                'Sid': 'ReadApplicationAndDatabaseLogs',
+                'Sid': 'ReadApplicationLogs',
                 'Effect': 'Allow',
                 'Action': [
                     'logs:FilterLogEvents', 'logs:GetLogEvents', 'logs:GetLogGroupFields',
                     'logs:GetLogRecord', 'logs:StartQuery', 'logs:StopQuery',
                     'logs:GetQueryResults',
                 ],
-                'Resource': (self._build_log_group_arns(self.human_access_log_group_prefix())
-                             + self.human_access_rds_log_group_arns()),
+                'Resource': self._log_group_arns(),
             },
             {
-                'Sid': 'InspectApplicationBucketConfiguration',
+                'Sid': 'InspectBucketConfiguration',
                 'Effect': 'Allow',
                 'Action': [
                     's3:ListBucket', 's3:GetBucketLocation', 's3:GetBucketVersioning',
@@ -990,47 +930,78 @@ class C4IAM(C4IAMBase, C4Part):
                     's3:GetEncryptionConfiguration', 's3:GetLifecycleConfiguration',
                     's3:GetBucketPublicAccessBlock', 's3:GetBucketTagging', 's3:GetBucketCORS',
                 ],
-                'Resource': self.human_access_bucket_arns(),
+                'Resource': 'arn:aws:s3:::*',
             },
             {
-                'Sid': 'ReadObjectsInApplicationBucketsOnly',
+                'Sid': 'ReadObjects',
                 'Effect': 'Allow',
                 'Action': ['s3:GetObject', 's3:GetObjectVersion', 's3:GetObjectTagging'],
-                'Resource': self.human_access_object_arns(),
+                'Resource': 'arn:aws:s3:::*/*',
             },
             {
-                'Sid': 'ReadApplicationSecretsOnly',
+                'Sid': 'ReadSecrets',
                 'Effect': 'Allow',
                 'Action': [
                     'secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret',
                     'secretsmanager:ListSecretVersionIds', 'secretsmanager:GetResourcePolicy',
                 ],
-                'Resource': self.human_access_secret_arns(),
+                'Resource': self._service_arn('secretsmanager', 'secret:*'),
+            },
+            {
+                'Sid': 'InspectQueueDepth',
+                'Effect': 'Allow',
+                # Depth and age only. Message bodies are application data - ReceiveMessage is
+                # denied in the guardrail policy below.
+                'Action': ['sqs:GetQueueAttributes', 'sqs:GetQueueUrl'],
+                'Resource': self._service_arn('sqs', '*'),
+            },
+            {
+                'Sid': 'InspectContainerImages',
+                'Effect': 'Allow',
+                'Action': [
+                    'ecr:DescribeRepositories', 'ecr:DescribeImages', 'ecr:ListImages',
+                    'ecr:BatchGetImage', 'ecr:GetRepositoryPolicy', 'ecr:GetLifecyclePolicy',
+                ],
+                'Resource': self._service_arn('ecr', 'repository/*'),
+            },
+            {
+                'Sid': 'InspectBuildsAndWorkflows',
+                'Effect': 'Allow',
+                'Action': ['codebuild:BatchGetBuilds', 'codebuild:BatchGetProjects'],
+                'Resource': self._service_arn('codebuild', 'project/*'),
+            },
+            {
+                'Sid': 'InspectWorkflowExecutions',
+                'Effect': 'Allow',
+                'Action': ['states:DescribeStateMachine', 'states:DescribeExecution',
+                           'states:GetExecutionHistory'],
+                'Resource': self._service_arn('states', '*'),
+            },
+            {
+                'Sid': 'InspectKeyMetadata',
+                'Effect': 'Allow',
+                # Metadata only: no key material, no ciphertext, no key policy.
+                'Action': ['kms:DescribeKey', 'kms:GetKeyRotationStatus'],
+                'Resource': self._service_arn('kms', 'key/*'),
             },
             {
                 'Sid': 'InspectOwnRoleDefinition',
                 'Effect': 'Allow',
                 'Action': ['iam:GetRole', 'iam:GetRolePolicy', 'iam:ListRolePolicies',
                            'iam:ListAttachedRolePolicies'],
-                'Resource': self._build_iam_role_arn(f'{self.name.stack_name}-*'),
+                'Resource': Join(':', ['arn', 'aws', 'iam', '', AccountId, 'role/*']),
             },
         ]
-        kms_key_arns = self.human_access_kms_key_arns()
-        if kms_key_arns:
-            # Key-policy reads (and optionally Decrypt) on the one configured key. Plain key
-            # metadata is granted region-pinned in the observability policy instead, so that
-            # "which key encrypts this bucket" is still answerable when no key is configured here.
-            kms_actions = ['kms:GetKeyPolicy']
-            if self._human_access_flag(Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT):
-                # Needed to read objects in an SSE-KMS bucket. KMS requires dual authorization, so
-                # this grant is inert until the key policy also names this role - which is a
-                # separate, out-of-band change, not something this template can make.
-                kms_actions.append('kms:Decrypt')
+        if self._human_access_flag(Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT):
+            # Off by default. Needed to read objects in an SSE-KMS bucket, and at service scope
+            # that means any key in the account - hence its own explicit switch. KMS also requires
+            # dual authorization, so this grant stays inert until the key policy names the role,
+            # which is a separate out-of-band change this template cannot make.
             statements.append({
-                'Sid': 'ConfiguredEncryptionKeyOnly',
+                'Sid': 'DecryptWithApplicationKeys',
                 'Effect': 'Allow',
-                'Action': kms_actions,
-                'Resource': kms_key_arns,
+                'Action': ['kms:Decrypt', 'kms:GetKeyPolicy'],
+                'Resource': self._service_arn('kms', 'key/*'),
             })
         return Policy(
             PolicyName='HumanDiagnoseResourceReadPolicy',
@@ -1054,11 +1025,14 @@ class C4IAM(C4IAMBase, C4Part):
             # Postgres logs can carry query text, and therefore data.
             'rds:DownloadDBLogFilePortion', 'rds:DownloadCompleteDBLogFile',
             'dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:Scan',
-            # Queue depth comes from GetQueueAttributes; message bodies are application data.
+            # Queue depth comes from GetQueueAttributes; message bodies are application data, and
+            # ChangeMessageVisibility is a remediation action rather than a read.
             'sqs:ReceiveMessage', 'sqs:SendMessage', 'sqs:DeleteMessage', 'sqs:PurgeQueue',
+            'sqs:ChangeMessageVisibility',
             # GetFunctionConfiguration returns environment variables and GetFunction returns a
             # presigned code download URL; both are configuration exfiltration paths.
             'lambda:GetFunction', 'lambda:GetFunctionConfiguration', 'lambda:InvokeFunction',
+            'lambda:UpdateFunctionCode', 'lambda:UpdateFunctionConfiguration',
             'es:ESHttp*',
             'ecs:UpdateService', 'ecs:StopTask', 'ecs:RunTask', 'ecs:StartTask',
             'ecs:RegisterTaskDefinition', 'ecs:CreateService', 'ecs:DeleteService',
@@ -1075,8 +1049,8 @@ class C4IAM(C4IAMBase, C4Part):
             'sts:GetFederationToken',
         ]
         if not cls._human_access_flag(Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT):
-            actions += ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:GenerateDataKeyWithoutPlaintext',
-                        'kms:ReEncryptFrom']
+            actions += ['kms:Decrypt', 'kms:GenerateDataKey',
+                        'kms:GenerateDataKeyWithoutPlaintext', 'kms:ReEncryptFrom']
         return Policy(
             PolicyName='HumanDiagnoseGuardrailPolicy',
             PolicyDocument={
@@ -1111,7 +1085,8 @@ class C4IAM(C4IAMBase, C4Part):
     @classmethod
     def human_remediate_read_policy(cls) -> Policy:
         """ The reads a power user needs to target a remediation safely - you cannot restart a
-            service you cannot find, or purge a queue without first confirming its backlog.
+            service you cannot find, or release in-flight messages without first seeing the
+            backlog. Same '*'-with-region-pin rationale as the diagnostic observability policy.
 
             Deliberately narrower than the diagnostic role's reads: no secrets, no S3, no KMS, no
             service quotas, no tag inventory. That keeps CloudTrail cleanly separable into
@@ -1126,18 +1101,19 @@ class C4IAM(C4IAMBase, C4Part):
                     'Effect': 'Allow',
                     'Action': [
                         'sts:GetCallerIdentity',
-                        'ecs:Describe*', 'ecs:List*',
+                        'ecs:DescribeClusters', 'ecs:DescribeServices', 'ecs:DescribeTasks',
+                        'ecs:DescribeTaskDefinition', 'ecs:ListClusters', 'ecs:ListServices',
+                        'ecs:ListTasks',
                         'elasticloadbalancing:DescribeLoadBalancers',
                         'elasticloadbalancing:DescribeTargetGroups',
                         'elasticloadbalancing:DescribeTargetHealth',
-                        'sqs:GetQueueAttributes', 'sqs:GetQueueUrl', 'sqs:ListQueues',
-                        'cloudwatch:Describe*', 'cloudwatch:Get*', 'cloudwatch:List*',
-                        'logs:Describe*', 'logs:List*',
-                        'ecr:Describe*', 'ecr:List*', 'ecr:BatchGetImage',
-                        'codebuild:BatchGet*', 'codebuild:List*',
-                        'states:Describe*', 'states:List*', 'states:GetExecutionHistory',
-                        'cloudformation:Describe*', 'cloudformation:List*',
-                        'rds:Describe*', 'es:Describe*', 'es:List*', 'ec2:Describe*',
+                        'cloudwatch:DescribeAlarms', 'cloudwatch:GetMetricData',
+                        'logs:DescribeLogGroups', 'logs:DescribeLogStreams',
+                        'sqs:ListQueues',
+                        'codebuild:ListProjects', 'codebuild:ListBuilds',
+                        'states:ListStateMachines', 'states:ListExecutions',
+                        'cloudformation:DescribeStacks', 'cloudformation:ListStacks',
+                        'rds:DescribeDBInstances', 'es:DescribeDomain', 'es:ListDomainNames',
                     ],
                     'Resource': '*',
                     'Condition': cls._region_pin(),
@@ -1146,93 +1122,81 @@ class C4IAM(C4IAMBase, C4Part):
         )
 
     @classmethod
-    def human_remediate_action_statements(cls) -> list:
-        """ One statement per remediation capability, each built only from explicitly supplied
-            resource ARNs. An empty ARN list means the capability is simply absent - there is no
-            derived-name or wildcard fallback anywhere in here, which is what keeps an
-            unnamed (e.g. live green) environment out of reach.
+    def human_remediate_action_policy(cls) -> Policy:
+        """ The exact operational actions needed to remediate the supported services, each scoped
+            to the service and gated on region plus (normally) a live MFA session.
+
+            Every one is reversible. Excluded on purpose: sqs:PurgeQueue and sqs:DeleteQueue
+            (irreversible - messages are gone), anything that authors or runs new code
+            (ecr:PutImage, ecs:RegisterTaskDefinition, ecs:RunTask, ecs:ExecuteCommand,
+            lambda:UpdateFunctionCode), IAM administration, and any unrelated data-plane or
+            network mutation.
         """
-        statements = []
         condition = cls._human_access_mutation_condition()
-
-        service_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS)
-        if service_arns:
-            # Note: IAM has no condition key for the task-definition argument of UpdateService, so
-            # this also permits repointing a named service at another already-registered revision.
-            # Bounded by ecr:PutImage being denied in the boundary, and by CloudTrail attribution.
-            statements.append({
-                'Sid': 'RestartOrRescaleNamedServices', 'Effect': 'Allow',
-                'Action': ['ecs:UpdateService'], 'Resource': service_arns,
-                'Condition': condition,
-            })
-
-        cluster_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS)
-        if cluster_arns:
-            task_condition = dict(condition, ArnEquals={'ecs:cluster': cluster_arns})
-            statements.append({
-                'Sid': 'StopIndividualStuckTasks', 'Effect': 'Allow',
-                'Action': ['ecs:StopTask'],
-                'Resource': [cls._task_arn_for_cluster(arn) for arn in cluster_arns],
-                'Condition': task_condition,
-            })
-
-        queue_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS)
-        if queue_arns:
-            statements.append({
-                'Sid': 'ReleaseInFlightQueueMessages', 'Effect': 'Allow',
-                'Action': ['sqs:ChangeMessageVisibility'], 'Resource': queue_arns,
-                'Condition': condition,
-            })
-            if cls._human_access_flag(Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE):
-                # Irreversible: purged messages are gone. Its own explicit, default-off switch.
-                statements.append({
-                    'Sid': 'PurgeNamedQueues', 'Effect': 'Allow',
-                    'Action': ['sqs:PurgeQueue'], 'Resource': queue_arns,
-                    'Condition': condition,
-                })
-
-        state_machine_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS)
-        if state_machine_arns:
-            statements.append({
-                'Sid': 'StartNamedStateMachines', 'Effect': 'Allow',
-                'Action': ['states:StartExecution'], 'Resource': state_machine_arns,
-                'Condition': condition,
-            })
-            statements.append({
-                'Sid': 'StopExecutionsOfNamedStateMachines', 'Effect': 'Allow',
-                'Action': ['states:StopExecution'],
-                'Resource': [cls._execution_arn_for_state_machine(arn) for arn in state_machine_arns],
-                'Condition': condition,
-            })
-
-        codebuild_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS)
-        if codebuild_arns:
-            # Rebuilding through CI is the only sanctioned way to change what runs: the build runs
-            # under CodeBuild's own role from the pinned repo/branch, and the human never pushes
-            # an image (ecr:PutImage is denied).
-            statements.append({
-                'Sid': 'RebuildApplicationImageViaCiOnly', 'Effect': 'Allow',
-                'Action': ['codebuild:StartBuild', 'codebuild:StopBuild', 'codebuild:RetryBuild'],
-                'Resource': codebuild_arns, 'Condition': condition,
-            })
-        return statements
-
-    @staticmethod
-    def _task_arn_for_cluster(cluster_arn: str) -> str:
-        """ arn:aws:ecs:<region>:<acct>:cluster/<name> -> arn:aws:ecs:<region>:<acct>:task/<name>/*
-        """
-        return cluster_arn.replace(':cluster/', ':task/', 1) + '/*'
-
-    @staticmethod
-    def _execution_arn_for_state_machine(state_machine_arn: str) -> str:
-        """ ...:stateMachine:<name> -> ...:execution:<name>:* (the resource StopExecution takes).
-        """
-        return state_machine_arn.replace(':stateMachine:', ':execution:', 1) + ':*'
+        return Policy(
+            PolicyName='HumanRemediateActionPolicy',
+            PolicyDocument={
+                'Version': '2012-10-17',
+                'Statement': [
+                    {
+                        # Restart (force-new-deployment) or rescale (desired-count) a service.
+                        'Sid': 'RestartOrRescaleServices',
+                        'Effect': 'Allow',
+                        'Action': ['ecs:UpdateService'],
+                        'Resource': cls._service_arn('ecs', 'service/*'),
+                        'Condition': condition,
+                    },
+                    {
+                        # Kill one stuck task; the service replaces it.
+                        'Sid': 'StopStuckTasks',
+                        'Effect': 'Allow',
+                        'Action': ['ecs:StopTask'],
+                        'Resource': cls._service_arn('ecs', 'task/*'),
+                        'Condition': condition,
+                    },
+                    {
+                        # Release in-flight messages back to the queue. Reversible: nothing is
+                        # destroyed, the messages simply become visible again.
+                        'Sid': 'ReleaseInFlightQueueMessages',
+                        'Effect': 'Allow',
+                        'Action': ['sqs:ChangeMessageVisibility'],
+                        'Resource': cls._service_arn('sqs', '*'),
+                        'Condition': condition,
+                    },
+                    {
+                        # Rerun a stuck workflow.
+                        'Sid': 'StartWorkflowExecutions',
+                        'Effect': 'Allow',
+                        'Action': ['states:StartExecution'],
+                        'Resource': cls._service_arn('states', 'stateMachine:*'),
+                        'Condition': condition,
+                    },
+                    {
+                        'Sid': 'StopWorkflowExecutions',
+                        'Effect': 'Allow',
+                        'Action': ['states:StopExecution'],
+                        'Resource': cls._service_arn('states', 'execution:*'),
+                        'Condition': condition,
+                    },
+                    {
+                        # Rebuild through CI - the only sanctioned way to change what runs. The
+                        # build runs under CodeBuild's own role from the pinned repo and branch,
+                        # and the human never pushes an image (ecr:PutImage is denied).
+                        'Sid': 'RebuildApplicationImageViaCiOnly',
+                        'Effect': 'Allow',
+                        'Action': ['codebuild:StartBuild', 'codebuild:StopBuild',
+                                   'codebuild:RetryBuild'],
+                        'Resource': cls._service_arn('codebuild', 'project/*'),
+                        'Condition': condition,
+                    },
+                ],
+            },
+        )
 
     @classmethod
     def human_remediate_guardrail_policy(cls) -> Policy:
         """ Denies that hold whether or not the boundary is attached: no way to author or run new
-            code, no data or secret reads, and no chaining to another role.
+            code, no irreversible queue operation, no data or secret reads, no chaining.
         """
         return Policy(
             PolicyName='HumanRemediateGuardrailPolicy',
@@ -1240,7 +1204,7 @@ class C4IAM(C4IAMBase, C4Part):
                 'Version': '2012-10-17',
                 'Statement': [
                     {
-                        'Sid': 'RemediationCannotSupplyCodeOrReadData',
+                        'Sid': 'RemediationCannotSupplyCodeDestroyDataOrReadIt',
                         'Effect': 'Deny',
                         'Action': [
                             'ecs:RegisterTaskDefinition', 'ecs:DeregisterTaskDefinition',
@@ -1253,13 +1217,15 @@ class C4IAM(C4IAMBase, C4Part):
                             'lambda:UpdateFunctionCode', 'lambda:UpdateFunctionConfiguration',
                             'lambda:InvokeFunction', 'lambda:GetFunction',
                             'lambda:GetFunctionConfiguration',
+                            # Irreversible queue operations are excluded from remediation.
+                            'sqs:PurgeQueue', 'sqs:DeleteQueue',
+                            'sqs:ReceiveMessage', 'sqs:SendMessage', 'sqs:DeleteMessage',
                             's3:GetObject', 's3:GetObjectVersion', 's3:PutObject',
                             's3:DeleteObject',
                             'secretsmanager:GetSecretValue',
                             'kms:Decrypt', 'kms:GenerateDataKey',
                             'kms:GenerateDataKeyWithoutPlaintext', 'kms:ReEncryptFrom',
                             'ssm:GetParameter', 'ssm:GetParameters', 'ssm:GetParametersByPath',
-                            'sqs:ReceiveMessage', 'sqs:SendMessage', 'sqs:DeleteMessage',
                             'rds:DownloadDBLogFilePortion', 'rds:DownloadCompleteDBLogFile',
                             'es:ESHttp*',
                             'iam:PassRole',
@@ -1277,17 +1243,6 @@ class C4IAM(C4IAMBase, C4Part):
         """ Scoped remediation role. Like the diagnostic role it attaches no managed policies and
             shares nothing with the ECS runtime role's helpers.
         """
-        policies = [self.human_remediate_read_policy()]
-        action_statements = self.human_remediate_action_statements()
-        if action_statements:
-            policies.append(Policy(
-                PolicyName='HumanRemediateActionPolicy',
-                PolicyDocument={'Version': '2012-10-17', 'Statement': action_statements},
-            ))
-        else:
-            logger.warning(f'{Settings.HUMAN_ACCESS_REMEDIATE_ENABLED} is on but no remediation'
-                           f' target ARNs were supplied; {self.REMEDIATE_ROLE} will be read-only.')
-        policies.append(self.human_remediate_guardrail_policy())
         return Role(
             self.REMEDIATE_ROLE,
             Description='Scoped remediation access for power users. Opt-in; see'
@@ -1295,7 +1250,11 @@ class C4IAM(C4IAMBase, C4Part):
             AssumeRolePolicyDocument=self.human_access_trust_policy(principal_arns),
             MaxSessionDuration=self.HUMAN_ACCESS_REMEDIATE_SESSION_DURATION,
             PermissionsBoundary=Ref(boundary),
-            Policies=policies,
+            Policies=[
+                self.human_remediate_read_policy(),
+                self.human_remediate_action_policy(),
+                self.human_remediate_guardrail_policy(),
+            ],
         )
 
     def output_human_access_role(self, role: Role) -> Output:

--- a/src/parts/iam.py
+++ b/src/parts/iam.py
@@ -1,3 +1,5 @@
+import logging
+
 from awacs.aws import PolicyDocument, Statement, Action, Principal, AWSPrincipal
 from awacs.ecr import (
     GetAuthorizationToken,
@@ -6,12 +8,15 @@ from awacs.ecr import (
     BatchCheckLayerAvailability,
 )
 from troposphere import Region, AccountId, Template, Ref, Output, Join
-from troposphere.iam import Role, InstanceProfile, Policy, User, AccessKey
-from ..base import ConfigManager
+from troposphere.iam import Role, InstanceProfile, ManagedPolicy, Policy, User, AccessKey
+from ..base import ConfigManager, Settings
 from ..constants import C4IAMBase
 from ..part import C4Part
 from ..exports import C4Exports, exportify
 from ..names import Names
+
+
+logger = logging.getLogger(__name__)
 
 
 class C4IAMExports(C4Exports):
@@ -43,6 +48,14 @@ class C4IAM(C4IAMBase, C4Part):
     DEV_ROLE = ConfigManager.app_case(if_cgap='CGAPDevRole',
                                       if_ff='FFDevRole',
                                       if_smaht='SMaHTDevRole')
+    # Opt-in human direct-access roles. Deliberately NOT named *DevRole* - the existing DEV_ROLE
+    # above is a different (much broader) thing and the two must be distinguishable in CloudTrail.
+    DIAGNOSE_ROLE = ConfigManager.app_case(if_cgap='CGAPDevDiagnoseRole',
+                                           if_ff='FFDevDiagnoseRole',
+                                           if_smaht='SMaHTDevDiagnoseRole')
+    REMEDIATE_ROLE = ConfigManager.app_case(if_cgap='CGAPPowerRemediateRole',
+                                            if_ff='FFPowerRemediateRole',
+                                            if_smaht='SMaHTPowerRemediateRole')
     INSTANCE_PROFILE_NAME = ConfigManager.app_case(if_cgap='CGAPECSInstanceProfile',
                                                    if_ff='FFECSInstanceProfile',
                                                    if_smaht='SMaHTInstanceProfile')
@@ -82,6 +95,52 @@ class C4IAM(C4IAMBase, C4Part):
         template.add_output(self.output_assumed_iam_role_or_user(dev_iam_role,
                                                                  export_name=C4IAMExports.DEV_IAM_ROLE))
         template.add_output(self.output_instance_profile(instance_profile))
+
+        # Opt-in human direct-access roles. Adds nothing at all unless explicitly enabled in
+        # template.config.json, so the template above is unchanged for every existing deployment.
+        self.build_human_access_roles(template)
+        return template
+
+    def build_human_access_roles(self, template: Template) -> Template:
+        """ Adds the opt-in human direct-access roles (and their shared permission boundary) to
+            the template, if and only if they are enabled in config. See the Settings block
+            'Human direct-AWS-access role options' for the full switch list.
+
+            This is a no-op by default. It is also a no-op when a role is enabled but no approved
+            principal ARNs were supplied, because the alternative - falling back to account-root
+            trust, as dev_user_role() does - is what makes such a role assumable by anything in
+            the account.
+        """
+        diagnose_wanted = self._human_access_flag(Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED)
+        remediate_wanted = self._human_access_flag(Settings.HUMAN_ACCESS_REMEDIATE_ENABLED)
+        if not (diagnose_wanted or remediate_wanted):
+            return template
+
+        diagnose_principals = self._human_access_list(Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS)
+        remediate_principals = self._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS)
+        build_diagnose = diagnose_wanted and bool(diagnose_principals)
+        build_remediate = remediate_wanted and bool(remediate_principals)
+        if diagnose_wanted and not build_diagnose:
+            logger.warning(f'{Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED} is on but'
+                           f' {Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS} is empty;'
+                           f' not creating {self.DIAGNOSE_ROLE}.')
+        if remediate_wanted and not build_remediate:
+            logger.warning(f'{Settings.HUMAN_ACCESS_REMEDIATE_ENABLED} is on but'
+                           f' {Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS} is empty;'
+                           f' not creating {self.REMEDIATE_ROLE}.')
+        if not (build_diagnose or build_remediate):
+            return template
+
+        boundary = self.human_access_boundary_policy()
+        template.add_resource(boundary)
+        if build_diagnose:
+            diagnose_role = self.human_diagnose_role(diagnose_principals, boundary)
+            template.add_resource(diagnose_role)
+            template.add_output(self.output_human_access_role(diagnose_role))
+        if build_remediate:
+            remediate_role = self.human_remediate_role(remediate_principals, boundary)
+            template.add_resource(remediate_role)
+            template.add_output(self.output_human_access_role(remediate_role))
         return template
 
     @staticmethod
@@ -515,6 +574,738 @@ class C4IAM(C4IAMBase, C4Part):
                 'arn:aws:iam::aws:policy/AmazonEC2FullAccess'  # full access to EC2 (tibanna)
             ],
             Policies=policies
+        )
+
+    # -------------------------------------------------------------------------------------------
+    # Human direct-AWS-access roles (opt-in; nothing below is built unless config enables it)
+    #
+    #   human_diagnose_role()  - read-only inspection of the running system. Keeps resource-scoped
+    #       Secrets Manager and S3 object reads, so a developer can gather evidence, plus the
+    #       observability reads needed to answer "is it up, why did it die, is it backed up".
+    #   human_remediate_role() - a small set of named, reversible operational writes, each one on
+    #       an explicitly supplied resource ARN.
+    #
+    # These are defined independently of the ecs_*_policy() helpers above on purpose. Sharing
+    # those helpers is exactly what makes dev_user_role() a superset of the ECS runtime role, and
+    # reusing them here would reintroduce that coupling. dev_user_role() itself is untouched.
+    # -------------------------------------------------------------------------------------------
+
+    @staticmethod
+    def _human_access_flag(setting: str) -> bool:
+        """ Reads a boolean opt-in setting, defaulting to off. ConfigManager already turns the
+            strings "true"/"false" into booleans, so tolerate either shape.
+        """
+        value = ConfigManager.get_config_setting(setting, default=False)
+        if isinstance(value, bool):
+            return value
+        return ConfigManager.str_to_bool(str(value)) is True
+
+    @staticmethod
+    def _human_access_list(setting: str) -> list:
+        """ Reads a comma-separated (or newline-separated) config setting as a list of strings,
+            defaulting to empty. Empty means "this capability is not granted".
+        """
+        value = ConfigManager.get_config_setting(setting, default='')
+        if not value or value is True:
+            return []
+        items = value if isinstance(value, list) else str(value).replace('\n', ',').split(',')
+        return [item.strip() for item in items if str(item).strip()]
+
+    @staticmethod
+    def _region_pin() -> dict:
+        """ Condition restricting a statement to the region this stack is deployed in. """
+        return {'StringEquals': {'aws:RequestedRegion': Region}}
+
+    @staticmethod
+    def _human_access_require_mfa() -> bool:
+        """ Whether to assert aws:MultiFactorAuthPresent. Defaults to True; set
+            human_access.require_mfa to false only for IAM Identity Center (SSO) accounts, where
+            MFA is asserted upstream at the IdP and this condition key cannot be relied on. Note
+            that a condition on a key absent from the request evaluates false, so leaving this on
+            in an SSO account fails closed rather than open.
+        """
+        value = ConfigManager.get_config_setting(Settings.HUMAN_ACCESS_REQUIRE_MFA, default=True)
+        if isinstance(value, bool):
+            return value
+        return ConfigManager.str_to_bool(str(value)) is not False
+
+    @classmethod
+    def _human_access_mutation_condition(cls) -> dict:
+        """ Conditions attached to every remediation write: this region, and normally a live MFA
+            session.
+        """
+        condition = cls._region_pin()
+        if cls._human_access_require_mfa():
+            condition['Bool'] = {'aws:MultiFactorAuthPresent': 'true'}
+        return condition
+
+    @staticmethod
+    def _build_log_group_arns(prefix: str) -> list:
+        """ Log groups created by this repo have no LogGroupName, so CloudFormation generates
+            '<stack-name>-<LogicalId>-<random>' and the ARN can only be matched by prefix.
+        """
+        return [
+            Join(':', ['arn', 'aws', 'logs', Region, AccountId, 'log-group', f'{prefix}*']),
+            Join(':', ['arn', 'aws', 'logs', Region, AccountId, 'log-group', f'{prefix}*', 'log-stream', '*']),
+        ]
+
+    @staticmethod
+    def _build_kms_key_arn(key_id: str):
+        return Join(':', ['arn', 'aws', 'kms', Region, AccountId, f'key/{key_id}'])
+
+    @staticmethod
+    def _build_iam_role_arn(name_pattern: str):
+        return Join(':', ['arn', 'aws', 'iam', '', AccountId, f'role/{name_pattern}'])
+
+    @classmethod
+    def human_access_log_group_prefix(cls) -> str:
+        """ The logging stack's name, which every application log group's physical name starts
+            with. The logging part is ecosystem-shared (see C4Logging.SHARING).
+        """
+        from .logging import C4Logging  # deferred: avoids an import cycle between IAM and logging
+        return f'{C4Logging.suggest_stack_name().stack_name}-'
+
+    @classmethod
+    def human_access_rds_log_group_arns(cls) -> list:
+        """ RDS publishes to /aws/rds/instance/<DBInstanceIdentifier>/..., where the identifier is
+            rds.name if configured, else rds-{env_name} (see C4Datastore.rds_instance).
+        """
+        env_name = ConfigManager.get_config_setting(Settings.ENV_NAME)
+        rds_name = ConfigManager.get_config_setting(Settings.RDS_NAME, default=None) or f'rds-{env_name}'
+        return cls._build_log_group_arns(f'/aws/rds/instance/{rds_name}/')
+
+    @classmethod
+    def human_access_secret_arns(cls) -> list:
+        """ The two secrets a developer needs to read to explain application behaviour: the
+            application configuration (GAC) and the RDS master secret. Names come from names.py,
+            so these are the real identifiers rather than a guessed prefix.
+        """
+        env_name = ConfigManager.get_config_setting(Settings.ENV_NAME)
+        return [
+            cls.builds_secret_manager_arn(Names.application_configuration_secret(env_name)),
+            cls.builds_secret_manager_arn(Names.rds_secret_logical_id(env_name)),
+        ]
+
+    @classmethod
+    def human_access_bucket_names(cls) -> list:
+        """ Buckets the diagnostic role may read objects from. Defaults to this deployment's own
+            derived application and foursight buckets; override with an explicit list where the
+            bucket names are legacy and do not follow the derived pattern (some do not).
+        """
+        configured = cls._human_access_list(Settings.HUMAN_ACCESS_DIAGNOSE_BUCKETS)
+        if configured:
+            return configured
+        templates = [
+            ConfigManager.AppBucketTemplate.BLOBS,
+            ConfigManager.AppBucketTemplate.FILES,
+            ConfigManager.AppBucketTemplate.WFOUT,
+            ConfigManager.AppBucketTemplate.SYSTEM,
+            ConfigManager.AppBucketTemplate.METADATA_BUNDLES,
+            ConfigManager.AppBucketTemplate.TIBANNA_OUTPUT,
+            ConfigManager.AppBucketTemplate.TIBANNA_CWL,
+            ConfigManager.FSBucketTemplate.ENVS,
+            ConfigManager.FSBucketTemplate.RESULTS,
+            ConfigManager.FSBucketTemplate.APPLICATION_VERSIONS,
+        ]
+        return [ConfigManager.resolve_bucket_name(template) for template in templates]
+
+    @classmethod
+    def human_access_bucket_arns(cls) -> list:
+        return [f'arn:aws:s3:::{name}' for name in cls.human_access_bucket_names()]
+
+    @classmethod
+    def human_access_object_arns(cls) -> list:
+        return [f'arn:aws:s3:::{name}/*' for name in cls.human_access_bucket_names()]
+
+    @classmethod
+    def human_access_kms_key_arns(cls) -> list:
+        """ The single configured S3 server-side-encryption key, or nothing. Never a wildcard. """
+        key_id = ConfigManager.get_config_setting(Settings.S3_ENCRYPT_KEY_ID, default=None)
+        return [cls._build_kms_key_arn(key_id)] if key_id else []
+
+    def human_access_trust_policy(self, principal_arns: list) -> dict:
+        """ Trust policy for a human-access role: only the enumerated principal ARNs, only with an
+            attributable session.
+
+            Deliberately NOT AWSPrincipal(AccountId): account-root trust in a role's trust policy
+            means any identity in the account holding sts:AssumeRole can assume it, which is how
+            dev_user_role() is reachable today.
+
+            Note on session length: MaxSessionDuration on the role is the control, not a condition
+            key. There is no sts:DurationSeconds condition key, and asserting a non-existent key
+            would evaluate false and make the role unassumable.
+        """
+        condition = {}
+        if self._human_access_require_mfa():
+            condition['Bool'] = {'aws:MultiFactorAuthPresent': 'true'}
+            condition['NumericLessThan'] = {'aws:MultiFactorAuthAge': '3600'}
+        source_identity_pattern = ConfigManager.get_config_setting(
+            Settings.HUMAN_ACCESS_SOURCE_IDENTITY_PATTERN, default=None)
+        if source_identity_pattern:
+            condition['StringLike'] = {'sts:SourceIdentity': source_identity_pattern}
+        allow_statement = {
+            'Sid': 'ApprovedHumanPrincipalsOnly',
+            'Effect': 'Allow',
+            'Principal': {'AWS': principal_arns},
+            'Action': ['sts:AssumeRole', 'sts:SetSourceIdentity'],
+        }
+        if condition:
+            allow_statement['Condition'] = condition
+        return {
+            'Version': '2012-10-17',
+            'Statement': [
+                allow_statement,
+                {
+                    # Every session must be attributable to a person in CloudTrail.
+                    'Sid': 'DenyAssumeWithoutSourceIdentity',
+                    'Effect': 'Deny',
+                    'Principal': {'AWS': '*'},
+                    'Action': 'sts:AssumeRole',
+                    'Condition': {'Null': {'sts:SourceIdentity': 'true'}},
+                },
+            ],
+        }
+
+    @classmethod
+    def human_access_region_deny_statement(cls) -> dict:
+        """ Deny anything outside this region. Global services are excepted because they are only
+            reachable through us-east-1 and denying them would break sts/iam self-inspection.
+        """
+        return {
+            'Sid': 'DenyOutsideHomeRegionExceptGlobalServices',
+            'Effect': 'Deny',
+            'NotAction': ['iam:*', 'sts:*', 'cloudfront:*', 'route53:*', 's3:ListAllMyBuckets',
+                          'support:*', 'organizations:*', 'health:*', 'budgets:*', 'ce:*'],
+            'Resource': '*',
+            'Condition': {'StringNotEquals': {'aws:RequestedRegion': Region}},
+        }
+
+    def human_access_boundary_policy(self) -> ManagedPolicy:
+        """ Permission boundary shared by both human-access roles.
+
+            This is the backstop that keeps a future additive edit to either role from quietly
+            granting identity administration, supply-chain writes, or data-plane writes. It is not
+            a substitute for the Deny statements on the roles themselves: a boundary caps the
+            role's own effective permissions and is neither inherited nor applied to
+            resource-based policies.
+
+            Where the roles are meant to have a narrow read (S3 objects, the two application
+            secrets, the one encryption key), the boundary denies the action everywhere *except*
+            those resources via NotResource, rather than dropping the deny altogether.
+        """
+        statements = [
+            {'Sid': 'AllowWhatIsNotExplicitlyForbidden', 'Effect': 'Allow',
+             'Action': '*', 'Resource': '*'},
+            {
+                'Sid': 'NeverIdentityOrgOrBillingAdministration',
+                'Effect': 'Deny',
+                'Action': [
+                    'iam:Create*', 'iam:Delete*', 'iam:Update*', 'iam:Put*', 'iam:Attach*',
+                    'iam:Detach*', 'iam:Add*', 'iam:Remove*', 'iam:Set*', 'iam:Tag*',
+                    'iam:Untag*', 'iam:ChangePassword', 'iam:PassRole',
+                    'sso:*', 'sso-admin:*', 'sso-directory:*', 'identitystore:*',
+                    'organizations:*', 'account:*', 'aws-portal:*', 'billing:*', 'ce:*',
+                    'budgets:*', 'cur:*', 'sts:GetFederationToken',
+                ],
+                'Resource': '*',
+            },
+            {
+                'Sid': 'NeverCodeSupplyChainOrArbitraryExecution',
+                'Effect': 'Deny',
+                'Action': [
+                    'ecr:PutImage', 'ecr:InitiateLayerUpload', 'ecr:UploadLayerPart',
+                    'ecr:CompleteLayerUpload', 'ecr:BatchDeleteImage', 'ecr:DeleteRepository',
+                    'ecr:SetRepositoryPolicy', 'ecr:PutImageTagMutability',
+                    'ecs:RegisterTaskDefinition', 'ecs:DeregisterTaskDefinition',
+                    'ecs:CreateService', 'ecs:DeleteService', 'ecs:CreateCluster',
+                    'ecs:DeleteCluster', 'ecs:RunTask', 'ecs:StartTask', 'ecs:ExecuteCommand',
+                    'lambda:CreateFunction', 'lambda:DeleteFunction', 'lambda:UpdateFunctionCode',
+                    'lambda:UpdateFunctionConfiguration', 'lambda:InvokeFunction',
+                    'lambda:AddPermission', 'lambda:AddLayerVersionPermission',
+                    'codebuild:CreateProject', 'codebuild:UpdateProject',
+                    'codebuild:DeleteProject', 'codebuild:UpdateProjectVisibility',
+                    'states:CreateStateMachine', 'states:UpdateStateMachine',
+                    'states:DeleteStateMachine',
+                    'ssm:SendCommand', 'ssm:StartSession',
+                ],
+                'Resource': '*',
+            },
+            {
+                'Sid': 'NeverInfrastructureOrPerimeterMutation',
+                'Effect': 'Deny',
+                'Action': [
+                    'cloudformation:CreateStack', 'cloudformation:UpdateStack',
+                    'cloudformation:DeleteStack', 'cloudformation:CreateChangeSet',
+                    'cloudformation:ExecuteChangeSet', 'cloudformation:SetStackPolicy',
+                    'cloudformation:UpdateTerminationProtection', 'cloudformation:CreateStackSet',
+                    'cloudformation:UpdateStackSet', 'cloudformation:CreateStackInstances',
+                    'ec2:AuthorizeSecurityGroup*', 'ec2:RevokeSecurityGroup*',
+                    'ec2:CreateSecurityGroup', 'ec2:DeleteSecurityGroup',
+                    'ec2:ModifySecurityGroupRules', 'ec2:*Vpc*', 'ec2:*Subnet*', 'ec2:*Route*',
+                    'ec2:*InternetGateway*', 'ec2:*NatGateway*', 'ec2:*NetworkAcl*',
+                    'ec2:RunInstances', 'ec2:TerminateInstances',
+                    'elasticloadbalancing:Create*', 'elasticloadbalancing:Delete*',
+                    'elasticloadbalancing:Modify*', 'elasticloadbalancing:Set*',
+                    'es:Create*', 'es:Delete*', 'es:Update*',
+                    'rds:Create*', 'rds:Delete*', 'rds:Modify*', 'rds:Restore*', 'rds:Reboot*',
+                    'rds:Stop*', 'rds:Start*', 'rds:Promote*', 'rds:Copy*',
+                    'elasticache:Delete*', 'elasticache:Modify*',
+                    'cloudtrail:StopLogging', 'cloudtrail:DeleteTrail', 'cloudtrail:UpdateTrail',
+                    'cloudtrail:PutEventSelectors', 'config:DeleteConfigRule',
+                    'config:StopConfigurationRecorder', 'guardduty:DeleteDetector',
+                    'guardduty:UpdateDetector',
+                    'logs:DeleteLogGroup', 'logs:DeleteLogStream',
+                ],
+                'Resource': '*',
+            },
+            {
+                'Sid': 'NeverDataPlaneWrites',
+                'Effect': 'Deny',
+                'Action': [
+                    's3:PutObject*', 's3:DeleteObject*', 's3:DeleteBucket', 's3:PutBucket*',
+                    's3:PutEncryptionConfiguration', 's3:PutLifecycleConfiguration',
+                    's3:PutReplicationConfiguration',
+                    'secretsmanager:PutSecretValue', 'secretsmanager:UpdateSecret',
+                    'secretsmanager:DeleteSecret', 'secretsmanager:RotateSecret',
+                    'secretsmanager:PutResourcePolicy', 'secretsmanager:DeleteResourcePolicy',
+                    'kms:PutKeyPolicy', 'kms:ScheduleKeyDeletion', 'kms:DisableKey',
+                    'kms:CreateGrant', 'kms:RetireGrant', 'kms:RevokeGrant',
+                    'ssm:PutParameter', 'ssm:DeleteParameter',
+                    'dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem',
+                    'es:ESHttpPost', 'es:ESHttpPut', 'es:ESHttpDelete', 'es:ESHttpPatch',
+                ],
+                'Resource': '*',
+            },
+        ]
+        # Reads the roles are meant to have, denied everywhere but on those exact resources.
+        statements.append(self._boundary_scoped_read_deny(
+            'BoundS3ObjectReadsToApplicationBuckets',
+            ['s3:GetObject', 's3:GetObjectVersion', 's3:GetObjectTagging', 's3:GetObjectTorrent'],
+            self.human_access_object_arns()))
+        statements.append(self._boundary_scoped_read_deny(
+            'BoundSecretReadsToApplicationSecrets',
+            ['secretsmanager:GetSecretValue'],
+            self.human_access_secret_arns()))
+        statements.append(self._boundary_scoped_read_deny(
+            'BoundKmsUseToConfiguredEncryptionKey',
+            ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:GenerateDataKeyWithoutPlaintext',
+             'kms:ReEncryptFrom'],
+            self.human_access_kms_key_arns()))
+        statements.append(self.human_access_region_deny_statement())
+        return ManagedPolicy(
+            self.name.logical_id('HumanAccessBoundary'),
+            Description='Permission boundary for the opt-in human direct-access roles.',
+            PolicyDocument={'Version': '2012-10-17', 'Statement': statements},
+        )
+
+    @staticmethod
+    def _boundary_scoped_read_deny(sid: str, actions: list, allowed_resources: list) -> dict:
+        """ Deny these actions everywhere except on allowed_resources; if there is nothing to
+            carve out, deny them outright.
+        """
+        statement = {'Sid': sid, 'Effect': 'Deny', 'Action': actions}
+        if allowed_resources:
+            statement['NotResource'] = allowed_resources
+        else:
+            statement['Resource'] = '*'
+        return statement
+
+    @classmethod
+    def human_diagnose_observability_policy(cls) -> Policy:
+        """ The service-specific read APIs needed to inspect a running deployment. Almost all of
+            these Describe/List/Get APIs have no resource-level authorization at all, so they are
+            on '*' and constrained by region instead.
+
+            cloudformation:Detect* is deliberately absent: drift detection starts a job, which is
+            not a read, and it is not needed to inspect a service.
+        """
+        return Policy(
+            PolicyName='HumanDiagnoseObservabilityPolicy',
+            PolicyDocument={
+                'Version': '2012-10-17',
+                'Statement': [{
+                    'Sid': 'RegionPinnedServiceStateReads',
+                    'Effect': 'Allow',
+                    'Action': [
+                        'sts:GetCallerIdentity',
+                        'ecs:Describe*', 'ecs:List*',
+                        'elasticloadbalancing:Describe*',
+                        'application-autoscaling:Describe*',
+                        'cloudwatch:Describe*', 'cloudwatch:Get*', 'cloudwatch:List*',
+                        'logs:Describe*', 'logs:List*',
+                        'rds:Describe*', 'rds:ListTagsForResource',
+                        'es:Describe*', 'es:List*', 'es:Get*',
+                        'sqs:GetQueueAttributes', 'sqs:GetQueueUrl', 'sqs:ListQueues',
+                        'elasticache:Describe*', 'elasticache:List*',
+                        'cloudformation:Describe*', 'cloudformation:List*', 'cloudformation:Get*',
+                        'ecr:Describe*', 'ecr:List*', 'ecr:GetLifecyclePolicy',
+                        'ecr:GetRepositoryPolicy', 'ecr:BatchGetImage',
+                        'ecr:GetAuthorizationToken',
+                        'codebuild:BatchGet*', 'codebuild:List*',
+                        'states:Describe*', 'states:List*', 'states:GetExecutionHistory',
+                        'lambda:GetPolicy', 'lambda:GetAlias', 'lambda:List*',
+                        'ec2:Describe*',
+                        'servicequotas:Get*', 'servicequotas:List*',
+                        'tag:GetResources', 'tag:GetTagKeys', 'tag:GetTagValues',
+                        'secretsmanager:ListSecrets',
+                        # Key metadata only - no key material and no ciphertext access. Needed to
+                        # answer "is this bucket encrypted, and with which key": the key ARN comes
+                        # from s3:GetEncryptionConfiguration, so it cannot be scoped in advance,
+                        # and buckets may use AWS-managed keys that no config setting names. The
+                        # more revealing kms:GetKeyPolicy stays scoped to the configured key below.
+                        'kms:DescribeKey', 'kms:GetKeyRotationStatus', 'kms:ListAliases',
+                    ],
+                    'Resource': '*',
+                    'Condition': cls._region_pin(),
+                }],
+            },
+        )
+
+    def human_diagnose_resource_read_policy(self) -> Policy:
+        """ The resource-scoped half of diagnosis: application logs, the application buckets, the
+            two application secrets, encryption-key metadata, and this role's own definition.
+
+            Secrets Manager and S3 object reads are retained here on purpose - a developer is
+            expected to inspect the system and bring evidence - but only on the specific secrets
+            and buckets this deployment owns, never on '*'.
+        """
+        statements = [
+            {
+                'Sid': 'ReadApplicationAndDatabaseLogs',
+                'Effect': 'Allow',
+                'Action': [
+                    'logs:FilterLogEvents', 'logs:GetLogEvents', 'logs:GetLogGroupFields',
+                    'logs:GetLogRecord', 'logs:StartQuery', 'logs:StopQuery',
+                    'logs:GetQueryResults',
+                ],
+                'Resource': (self._build_log_group_arns(self.human_access_log_group_prefix())
+                             + self.human_access_rds_log_group_arns()),
+            },
+            {
+                'Sid': 'InspectApplicationBucketConfiguration',
+                'Effect': 'Allow',
+                'Action': [
+                    's3:ListBucket', 's3:GetBucketLocation', 's3:GetBucketVersioning',
+                    's3:GetBucketPolicy', 's3:GetBucketPolicyStatus',
+                    's3:GetEncryptionConfiguration', 's3:GetLifecycleConfiguration',
+                    's3:GetBucketPublicAccessBlock', 's3:GetBucketTagging', 's3:GetBucketCORS',
+                ],
+                'Resource': self.human_access_bucket_arns(),
+            },
+            {
+                'Sid': 'ReadObjectsInApplicationBucketsOnly',
+                'Effect': 'Allow',
+                'Action': ['s3:GetObject', 's3:GetObjectVersion', 's3:GetObjectTagging'],
+                'Resource': self.human_access_object_arns(),
+            },
+            {
+                'Sid': 'ReadApplicationSecretsOnly',
+                'Effect': 'Allow',
+                'Action': [
+                    'secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret',
+                    'secretsmanager:ListSecretVersionIds', 'secretsmanager:GetResourcePolicy',
+                ],
+                'Resource': self.human_access_secret_arns(),
+            },
+            {
+                'Sid': 'InspectOwnRoleDefinition',
+                'Effect': 'Allow',
+                'Action': ['iam:GetRole', 'iam:GetRolePolicy', 'iam:ListRolePolicies',
+                           'iam:ListAttachedRolePolicies'],
+                'Resource': self._build_iam_role_arn(f'{self.name.stack_name}-*'),
+            },
+        ]
+        kms_key_arns = self.human_access_kms_key_arns()
+        if kms_key_arns:
+            # Key-policy reads (and optionally Decrypt) on the one configured key. Plain key
+            # metadata is granted region-pinned in the observability policy instead, so that
+            # "which key encrypts this bucket" is still answerable when no key is configured here.
+            kms_actions = ['kms:GetKeyPolicy']
+            if self._human_access_flag(Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT):
+                # Needed to read objects in an SSE-KMS bucket. KMS requires dual authorization, so
+                # this grant is inert until the key policy also names this role - which is a
+                # separate, out-of-band change, not something this template can make.
+                kms_actions.append('kms:Decrypt')
+            statements.append({
+                'Sid': 'ConfiguredEncryptionKeyOnly',
+                'Effect': 'Allow',
+                'Action': kms_actions,
+                'Resource': kms_key_arns,
+            })
+        return Policy(
+            PolicyName='HumanDiagnoseResourceReadPolicy',
+            PolicyDocument={'Version': '2012-10-17', 'Statement': statements},
+        )
+
+    @classmethod
+    def human_diagnose_guardrail_policy(cls) -> Policy:
+        """ Explicit denies that make the diagnostic role read-only in its own right, rather than
+            relying on the absence of an Allow (or on the boundary staying attached).
+
+            sts:AssumeRole is denied so this role cannot be used as a stepping stone to the
+            remediation role or to the ECS runtime role - each privilege increase has to be a
+            fresh, separately audited assume from the human's own identity.
+        """
+        actions = [
+            's3:PutObject', 's3:DeleteObject', 's3:PutObjectAcl',
+            'secretsmanager:PutSecretValue', 'secretsmanager:UpdateSecret',
+            'secretsmanager:DeleteSecret', 'secretsmanager:RotateSecret',
+            'ssm:GetParameter', 'ssm:GetParameters', 'ssm:GetParametersByPath',
+            # Postgres logs can carry query text, and therefore data.
+            'rds:DownloadDBLogFilePortion', 'rds:DownloadCompleteDBLogFile',
+            'dynamodb:GetItem', 'dynamodb:Query', 'dynamodb:Scan',
+            # Queue depth comes from GetQueueAttributes; message bodies are application data.
+            'sqs:ReceiveMessage', 'sqs:SendMessage', 'sqs:DeleteMessage', 'sqs:PurgeQueue',
+            # GetFunctionConfiguration returns environment variables and GetFunction returns a
+            # presigned code download URL; both are configuration exfiltration paths.
+            'lambda:GetFunction', 'lambda:GetFunctionConfiguration', 'lambda:InvokeFunction',
+            'es:ESHttp*',
+            'ecs:UpdateService', 'ecs:StopTask', 'ecs:RunTask', 'ecs:StartTask',
+            'ecs:RegisterTaskDefinition', 'ecs:CreateService', 'ecs:DeleteService',
+            'ecs:ExecuteCommand',
+            'ecr:PutImage', 'ecr:InitiateLayerUpload', 'ecr:UploadLayerPart',
+            'ecr:CompleteLayerUpload', 'ecr:BatchDeleteImage',
+            'codebuild:StartBuild', 'codebuild:StopBuild', 'codebuild:RetryBuild',
+            'states:StartExecution', 'states:StopExecution',
+            'cloudwatch:PutMetricAlarm', 'cloudwatch:DeleteAlarms', 'cloudwatch:SetAlarmState',
+            'logs:PutRetentionPolicy',
+            'cloudformation:Detect*',
+            'iam:PassRole',
+            'sts:AssumeRole', 'sts:AssumeRoleWithSAML', 'sts:AssumeRoleWithWebIdentity',
+            'sts:GetFederationToken',
+        ]
+        if not cls._human_access_flag(Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT):
+            actions += ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:GenerateDataKeyWithoutPlaintext',
+                        'kms:ReEncryptFrom']
+        return Policy(
+            PolicyName='HumanDiagnoseGuardrailPolicy',
+            PolicyDocument={
+                'Version': '2012-10-17',
+                'Statement': [
+                    {'Sid': 'DiagnosisIsReadOnly', 'Effect': 'Deny',
+                     'Action': actions, 'Resource': '*'},
+                    cls.human_access_region_deny_statement(),
+                ],
+            },
+        )
+
+    def human_diagnose_role(self, principal_arns: list, boundary: ManagedPolicy) -> Role:
+        """ Read-only diagnosis role. No managed policies are attached: the ten attached to
+            dev_user_role() are what make it a superset of the ECS runtime role, and none of them
+            is narrow enough to reuse here.
+        """
+        return Role(
+            self.DIAGNOSE_ROLE,
+            Description='Read-only diagnosis access for developers. Opt-in; see'
+                        ' human_access.* in template.config.json.',
+            AssumeRolePolicyDocument=self.human_access_trust_policy(principal_arns),
+            MaxSessionDuration=self.HUMAN_ACCESS_DIAGNOSE_SESSION_DURATION,
+            PermissionsBoundary=Ref(boundary),
+            Policies=[
+                self.human_diagnose_observability_policy(),
+                self.human_diagnose_resource_read_policy(),
+                self.human_diagnose_guardrail_policy(),
+            ],
+        )
+
+    @classmethod
+    def human_remediate_read_policy(cls) -> Policy:
+        """ The reads a power user needs to target a remediation safely - you cannot restart a
+            service you cannot find, or purge a queue without first confirming its backlog.
+
+            Deliberately narrower than the diagnostic role's reads: no secrets, no S3, no KMS, no
+            service quotas, no tag inventory. That keeps CloudTrail cleanly separable into
+            "someone was looking" and "someone was changing".
+        """
+        return Policy(
+            PolicyName='HumanRemediateReadPolicy',
+            PolicyDocument={
+                'Version': '2012-10-17',
+                'Statement': [{
+                    'Sid': 'ReadsNeededToTargetARemediation',
+                    'Effect': 'Allow',
+                    'Action': [
+                        'sts:GetCallerIdentity',
+                        'ecs:Describe*', 'ecs:List*',
+                        'elasticloadbalancing:DescribeLoadBalancers',
+                        'elasticloadbalancing:DescribeTargetGroups',
+                        'elasticloadbalancing:DescribeTargetHealth',
+                        'sqs:GetQueueAttributes', 'sqs:GetQueueUrl', 'sqs:ListQueues',
+                        'cloudwatch:Describe*', 'cloudwatch:Get*', 'cloudwatch:List*',
+                        'logs:Describe*', 'logs:List*',
+                        'ecr:Describe*', 'ecr:List*', 'ecr:BatchGetImage',
+                        'codebuild:BatchGet*', 'codebuild:List*',
+                        'states:Describe*', 'states:List*', 'states:GetExecutionHistory',
+                        'cloudformation:Describe*', 'cloudformation:List*',
+                        'rds:Describe*', 'es:Describe*', 'es:List*', 'ec2:Describe*',
+                    ],
+                    'Resource': '*',
+                    'Condition': cls._region_pin(),
+                }],
+            },
+        )
+
+    @classmethod
+    def human_remediate_action_statements(cls) -> list:
+        """ One statement per remediation capability, each built only from explicitly supplied
+            resource ARNs. An empty ARN list means the capability is simply absent - there is no
+            derived-name or wildcard fallback anywhere in here, which is what keeps an
+            unnamed (e.g. live green) environment out of reach.
+        """
+        statements = []
+        condition = cls._human_access_mutation_condition()
+
+        service_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS)
+        if service_arns:
+            # Note: IAM has no condition key for the task-definition argument of UpdateService, so
+            # this also permits repointing a named service at another already-registered revision.
+            # Bounded by ecr:PutImage being denied in the boundary, and by CloudTrail attribution.
+            statements.append({
+                'Sid': 'RestartOrRescaleNamedServices', 'Effect': 'Allow',
+                'Action': ['ecs:UpdateService'], 'Resource': service_arns,
+                'Condition': condition,
+            })
+
+        cluster_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS)
+        if cluster_arns:
+            task_condition = dict(condition, ArnEquals={'ecs:cluster': cluster_arns})
+            statements.append({
+                'Sid': 'StopIndividualStuckTasks', 'Effect': 'Allow',
+                'Action': ['ecs:StopTask'],
+                'Resource': [cls._task_arn_for_cluster(arn) for arn in cluster_arns],
+                'Condition': task_condition,
+            })
+
+        queue_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS)
+        if queue_arns:
+            statements.append({
+                'Sid': 'ReleaseInFlightQueueMessages', 'Effect': 'Allow',
+                'Action': ['sqs:ChangeMessageVisibility'], 'Resource': queue_arns,
+                'Condition': condition,
+            })
+            if cls._human_access_flag(Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE):
+                # Irreversible: purged messages are gone. Its own explicit, default-off switch.
+                statements.append({
+                    'Sid': 'PurgeNamedQueues', 'Effect': 'Allow',
+                    'Action': ['sqs:PurgeQueue'], 'Resource': queue_arns,
+                    'Condition': condition,
+                })
+
+        state_machine_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS)
+        if state_machine_arns:
+            statements.append({
+                'Sid': 'StartNamedStateMachines', 'Effect': 'Allow',
+                'Action': ['states:StartExecution'], 'Resource': state_machine_arns,
+                'Condition': condition,
+            })
+            statements.append({
+                'Sid': 'StopExecutionsOfNamedStateMachines', 'Effect': 'Allow',
+                'Action': ['states:StopExecution'],
+                'Resource': [cls._execution_arn_for_state_machine(arn) for arn in state_machine_arns],
+                'Condition': condition,
+            })
+
+        codebuild_arns = cls._human_access_list(Settings.HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS)
+        if codebuild_arns:
+            # Rebuilding through CI is the only sanctioned way to change what runs: the build runs
+            # under CodeBuild's own role from the pinned repo/branch, and the human never pushes
+            # an image (ecr:PutImage is denied).
+            statements.append({
+                'Sid': 'RebuildApplicationImageViaCiOnly', 'Effect': 'Allow',
+                'Action': ['codebuild:StartBuild', 'codebuild:StopBuild', 'codebuild:RetryBuild'],
+                'Resource': codebuild_arns, 'Condition': condition,
+            })
+        return statements
+
+    @staticmethod
+    def _task_arn_for_cluster(cluster_arn: str) -> str:
+        """ arn:aws:ecs:<region>:<acct>:cluster/<name> -> arn:aws:ecs:<region>:<acct>:task/<name>/*
+        """
+        return cluster_arn.replace(':cluster/', ':task/', 1) + '/*'
+
+    @staticmethod
+    def _execution_arn_for_state_machine(state_machine_arn: str) -> str:
+        """ ...:stateMachine:<name> -> ...:execution:<name>:* (the resource StopExecution takes).
+        """
+        return state_machine_arn.replace(':stateMachine:', ':execution:', 1) + ':*'
+
+    @classmethod
+    def human_remediate_guardrail_policy(cls) -> Policy:
+        """ Denies that hold whether or not the boundary is attached: no way to author or run new
+            code, no data or secret reads, and no chaining to another role.
+        """
+        return Policy(
+            PolicyName='HumanRemediateGuardrailPolicy',
+            PolicyDocument={
+                'Version': '2012-10-17',
+                'Statement': [
+                    {
+                        'Sid': 'RemediationCannotSupplyCodeOrReadData',
+                        'Effect': 'Deny',
+                        'Action': [
+                            'ecs:RegisterTaskDefinition', 'ecs:DeregisterTaskDefinition',
+                            'ecs:CreateService', 'ecs:DeleteService', 'ecs:CreateCluster',
+                            'ecs:DeleteCluster', 'ecs:RunTask', 'ecs:StartTask',
+                            'ecs:ExecuteCommand',
+                            'ecr:PutImage', 'ecr:InitiateLayerUpload', 'ecr:UploadLayerPart',
+                            'ecr:CompleteLayerUpload', 'ecr:BatchDeleteImage',
+                            'ecr:PutImageTagMutability',
+                            'lambda:UpdateFunctionCode', 'lambda:UpdateFunctionConfiguration',
+                            'lambda:InvokeFunction', 'lambda:GetFunction',
+                            'lambda:GetFunctionConfiguration',
+                            's3:GetObject', 's3:GetObjectVersion', 's3:PutObject',
+                            's3:DeleteObject',
+                            'secretsmanager:GetSecretValue',
+                            'kms:Decrypt', 'kms:GenerateDataKey',
+                            'kms:GenerateDataKeyWithoutPlaintext', 'kms:ReEncryptFrom',
+                            'ssm:GetParameter', 'ssm:GetParameters', 'ssm:GetParametersByPath',
+                            'sqs:ReceiveMessage', 'sqs:SendMessage', 'sqs:DeleteMessage',
+                            'rds:DownloadDBLogFilePortion', 'rds:DownloadCompleteDBLogFile',
+                            'es:ESHttp*',
+                            'iam:PassRole',
+                            'sts:AssumeRole', 'sts:AssumeRoleWithSAML',
+                            'sts:AssumeRoleWithWebIdentity', 'sts:GetFederationToken',
+                        ],
+                        'Resource': '*',
+                    },
+                    cls.human_access_region_deny_statement(),
+                ],
+            },
+        )
+
+    def human_remediate_role(self, principal_arns: list, boundary: ManagedPolicy) -> Role:
+        """ Scoped remediation role. Like the diagnostic role it attaches no managed policies and
+            shares nothing with the ECS runtime role's helpers.
+        """
+        policies = [self.human_remediate_read_policy()]
+        action_statements = self.human_remediate_action_statements()
+        if action_statements:
+            policies.append(Policy(
+                PolicyName='HumanRemediateActionPolicy',
+                PolicyDocument={'Version': '2012-10-17', 'Statement': action_statements},
+            ))
+        else:
+            logger.warning(f'{Settings.HUMAN_ACCESS_REMEDIATE_ENABLED} is on but no remediation'
+                           f' target ARNs were supplied; {self.REMEDIATE_ROLE} will be read-only.')
+        policies.append(self.human_remediate_guardrail_policy())
+        return Role(
+            self.REMEDIATE_ROLE,
+            Description='Scoped remediation access for power users. Opt-in; see'
+                        ' human_access.* in template.config.json.',
+            AssumeRolePolicyDocument=self.human_access_trust_policy(principal_arns),
+            MaxSessionDuration=self.HUMAN_ACCESS_REMEDIATE_SESSION_DURATION,
+            PermissionsBoundary=Ref(boundary),
+            Policies=policies,
+        )
+
+    def output_human_access_role(self, role: Role) -> Output:
+        """ Outputs a human-access role name. Not exported: no other stack consumes these, and an
+            export would add a cross-stack dependency to an opt-in feature.
+        """
+        return Output(
+            self.name.logical_id(f'{role.title}Name'),
+            Description=f'Name of the {role.title} human direct-access role',
+            Value=Ref(role),
         )
 
     def ecs_instance_profile(self) -> InstanceProfile:

--- a/tests/test_human_access_regressions.py
+++ b/tests/test_human_access_regressions.py
@@ -1,0 +1,179 @@
+"""Adversarial, offline regressions for the human IAM policy contract (not an IAM simulator)."""
+import fnmatch
+import json
+from unittest import mock
+
+import pytest
+
+from src.base import ConfigManager
+from src.constants import Settings
+from src.parts.iam import C4IAM
+from .test_human_access_roles import (
+    ALICE, BOB, BOTH_ROLES, BOUNDARY_ID, ENABLED_BOTH, SSO_PRINCIPAL,
+    _actions, _allows, _build_template, _flat, _render, _resources, _role, _statements,
+)
+
+
+@pytest.mark.parametrize('setting', [Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS,
+                                     Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS])
+@pytest.mark.parametrize('value', [
+    '*', '123456789012', 'arn:aws:iam::123456789012:root',
+    'arn:aws:iam::123456789012:role/*', 'arn:aws:iam::123456789012:user/al?ce',
+    'arn:aws:sts::123456789012:assumed-role/Developer/alice',
+    'arn:aws:iam::123:user/alice', 'ec2.amazonaws.com',
+    'arn:aws-cn:iam::123456789012:role/Developer', [ALICE, 42], True, '[invalid',
+    '[__import__("os").getcwd()]',
+])
+def test_invalid_or_broad_trust_fails_synthesis(setting, value):
+    with pytest.raises(ValueError, match='concrete.*IAM user or role ARNs'):
+        _build_template(**dict(ENABLED_BOTH, **{setting: value}))
+
+
+@pytest.mark.parametrize('value', [f' {ALICE}\n{BOB}, {ALICE} ', [ALICE, ' ', BOB, ALICE]])
+def test_principal_lists_are_trimmed_and_deduplicated(value):
+    template = _build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: value}))
+    trust = _role(template, C4IAM.DIAGNOSE_ROLE)['AssumeRolePolicyDocument']
+    assert trust['Statement'][0]['Principal'] == {'AWS': [ALICE, BOB]}
+
+
+def test_json_array_principals_survive_real_config_loading(tmp_path):
+    path = tmp_path / 'config.json'
+    path.write_text(json.dumps({Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: [ALICE, BOB]}))
+    loaded = ConfigManager._load_config(path)
+    assert isinstance(loaded[Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS], str)
+    with mock.patch.object(ConfigManager.singleton(), '_get_config', return_value=loaded):
+        assert C4IAM._human_access_list(Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS) == [ALICE, BOB]
+
+
+def test_cross_account_trust_is_explicit_and_sso_paths_are_supported():
+    principal = 'arn:aws:iam::999999999999:role/team/ApprovedHuman'
+    template = _build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: [principal, SSO_PRINCIPAL]}))
+    trust = _role(template, C4IAM.DIAGNOSE_ROLE)['AssumeRolePolicyDocument']
+    assert trust['Statement'][0]['Principal']['AWS'] == [principal, SSO_PRINCIPAL]
+    assert trust['Statement'][0]['Condition']['Bool']['aws:MultiFactorAuthPresent'] == 'true'
+
+
+def test_oversized_trust_policy_fails_synthesis():
+    principals = [f'arn:aws:iam::123456789012:role/team/Operator{n}' for n in range(50)]
+    with pytest.raises(ValueError, match='2048-character limit'):
+        _build_template(**dict(ENABLED_BOTH, **{Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: principals}))
+
+
+def test_disabled_features_preserve_the_entire_template_and_ignore_unused_principals():
+    with mock.patch.object(C4IAM, 'build_human_access_roles', side_effect=lambda template: template):
+        legacy = _build_template()
+    assert _build_template() == legacy
+    assert _build_template(**{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED: 'false',
+        Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: '*',
+        Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS: ['invalid'],
+    }) == legacy
+    template = _build_template(**{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED: 'true',
+        Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: ALICE,
+        Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS: '*',
+    })
+    assert C4IAM.DIAGNOSE_ROLE in template['Resources']
+    assert C4IAM.REMEDIATE_ROLE not in template['Resources']
+
+
+@pytest.mark.parametrize('kms', [False, True])
+def test_no_inline_allow_is_nullified_by_an_unconditional_boundary_or_inline_deny(kms):
+    template = _build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: kms}))
+    boundary = template['Resources'][BOUNDARY_ID]['Properties']['PolicyDocument']['Statement']
+    for role_id in BOTH_ROLES:
+        role = _role(template, role_id)
+        denies = [s for s in _statements(role) + boundary
+                  if s['Effect'] == 'Deny' and 'Condition' not in s]
+        for allow in _allows(role):
+            for action in _actions(allow):
+                for deny in denies:
+                    assert not any(fnmatch.fnmatchcase(action.lower(), pattern.lower())
+                                   for pattern in _actions(deny)), (role_id, action, deny['Sid'])
+
+
+@pytest.mark.parametrize('action', ['s3:GetObject', 's3:GetObjectVersion', 's3:ListBucket'])
+def test_s3_reads_require_own_account_even_if_a_bucket_policy_grants_access(action):
+    template = _build_template(**ENABLED_BOTH)
+    role = _role(template, C4IAM.DIAGNOSE_ROLE)
+    allowing = [s for s in _allows(role) if action in _actions(s)]
+    assert len(allowing) == 1
+    assert allowing[0]['Condition'] == {'StringEquals': {'s3:ResourceAccount': {'Ref': 'AWS::AccountId'}}}
+    boundary = template['Resources'][BOUNDARY_ID]['Properties']['PolicyDocument']['Statement']
+    # Both the inline guardrail and boundary explicitly deny non-local or missing owner context;
+    # this is not merely an implicit deny that a grant to an STS session could bypass.
+    for statements in (_statements(role), boundary):
+        deny = next(s for s in statements if s['Sid'] == 'DenyS3OutsideThisAccount')
+        assert deny['Effect'] == 'Deny'
+        assert any(fnmatch.fnmatchcase(action, pattern) for pattern in _actions(deny))
+        assert deny['Resource'] == ['arn:aws:s3:::*', 'arn:aws:s3:::*/*']
+        assert deny['Condition'] == {'StringNotEquals': {'s3:ResourceAccount': {'Ref': 'AWS::AccountId'}}}
+
+
+@pytest.mark.parametrize('role_id', BOTH_ROLES)
+@pytest.mark.parametrize('action, resource', [
+    ('ecs:DescribeClusters', 'arn:aws:ecs:<region>:<account-id>:cluster/*'),
+    ('ecs:DescribeServices', 'arn:aws:ecs:<region>:<account-id>:service/*'),
+    ('ecs:DescribeTasks', 'arn:aws:ecs:<region>:<account-id>:task/*'),
+    ('cloudformation:DescribeStacks', 'arn:aws:cloudformation:<region>:<account-id>:stack/*'),
+    ('logs:DescribeLogStreams', 'arn:aws:logs:<region>:<account-id>:log-group:*'),
+    ('es:DescribeDomain', 'arn:aws:es:<region>:<account-id>:domain/*'),
+    ('rds:DescribeDBInstances', 'arn:aws:rds:<region>:<account-id>:db:*'),
+    ('states:ListExecutions', 'arn:aws:states:<region>:<account-id>:stateMachine:*'),
+])
+def test_resource_authorized_inspection_is_not_misclassified_as_wildcard_only(role_id, action, resource):
+    role = _role(_build_template(**ENABLED_BOTH), role_id)
+    allowing = [s for s in _allows(role) if action in _actions(s)]
+    assert len(allowing) == 1
+    assert [_render(r) for r in _resources(allowing[0])] == [resource]
+
+
+def test_stop_query_uses_the_required_wildcard_resource():
+    role = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    allowing = [s for s in _allows(role) if 'logs:StopQuery' in _actions(s)]
+    assert len(allowing) == 1
+    assert allowing[0]['Resource'] == '*'
+    assert allowing[0]['Condition']['StringEquals']['aws:RequestedRegion'] == {'Ref': 'AWS::Region'}
+
+
+@pytest.mark.parametrize('kms', [False, True])
+@pytest.mark.parametrize('mfa', [False, True])
+def test_enabled_templates_have_valid_local_cloudformation_references(kms, mfa):
+    template = _build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: kms,
+        Settings.HUMAN_ACCESS_REQUIRE_MFA: mfa}))
+
+    def check(value):
+        if isinstance(value, dict):
+            if 'Ref' in value:
+                ref = value['Ref']
+                assert ref.startswith('AWS::') or ref in template['Resources'], ref
+            for child in value.values():
+                check(child)
+        elif isinstance(value, list):
+            for child in value:
+                check(child)
+
+    check(template)
+    for role_id in BOTH_ROLES:
+        role = _role(template, role_id)
+        assert 'MultiFactorAuthPresent' not in _flat(role['Policies'])
+        trust = role['AssumeRolePolicyDocument']
+        assert ('MultiFactorAuthPresent' in _flat(trust)) is mfa
+        assert 'DenyAssumeWithoutSourceIdentity' in _flat(trust)
+
+
+def test_retained_build_delegation_is_not_described_as_a_sandbox():
+    from pathlib import Path
+    text = (Path(__file__).parents[1] / 'docs/source/human_access_roles.rst').read_text()
+    for phrase in ('buildspecOverride', 'RetryBuild', 'service role', 'one-hour', '1800',
+                   'not an enforced', 'key policy', 'credentials'):
+        assert phrase in text
+    role = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
+    for action in ('codebuild:StartBuild', 'codebuild:RetryBuild'):
+        allowing = [s for s in _allows(role) if action in _actions(s)]
+        assert len(allowing) == 1
+        assert allowing[0]['Condition'] == {'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}

--- a/tests/test_human_access_roles.py
+++ b/tests/test_human_access_roles.py
@@ -1,23 +1,22 @@
 """
 Static/template tests for the opt-in human direct-AWS-access roles built by C4IAM.
 
-These roles exist so a developer can inspect the running system, and a power user can perform the
-reversible operational actions needed to remediate it, without assuming the existing DevRole
+These roles exist so a developer can inspect the running system, and a power user can perform
+operational actions needed to remediate it, without assuming the existing DevRole
 (which is trusted by the account root and holds ten full-access managed policies).
 
 The scoping model these tests pin: the account holds only our own resources, so the policies do
 *not* enumerate resource identifiers. Where an action supports resource-level authorization it is
 scoped to the service (`arn:aws:ecs:<region>:<account>:service/*`, `arn:aws:s3:::*/*`, ...); where
-an action has no resource-level authorization at all, the resource is `"*"` and the statement is
-region-pinned instead. The constraint that carries the weight is therefore the *action list*, which
+discovery/inspection needs wildcard scope, the resource is `"*"` with region and resource-owner
+conditions (where AWS provides ownership). The main constraint is therefore the *action list*, which
 is fully enumerated - so these tests check that list closely.
 
 Covered here, in the order the requirements were stated:
 
   1. Disabled-default behaviour - no resources, outputs, parameters or conditions added.
   2. Trust restrictions - enumerated principal ARNs, attributable session, never account root.
-  3. Service-level resource scope - and `"*"` only in the two statements whose actions AWS gives
-     no ARN to scope to.
+  3. Service-level resource scope - and `"*"` only in explicit discovery/inspection groups.
   4. Constrained allowed actions - every action enumerated, no `service:*` and no `"*"`.
   5. Prohibited broad administration - no managed policies, and the administrative/destructive
      actions are explicitly denied.
@@ -40,10 +39,10 @@ from troposphere import Template
 
 
 TEST_ENV_NAME = 'cgap-build'
-TEST_ACCOUNT = '123456789'
-ALICE = 'arn:aws:iam::123456789:user/alice'
-BOB = 'arn:aws:iam::123456789:user/bob'
-SSO_PRINCIPAL = ('arn:aws:iam::123456789:role/aws-reserved/sso.amazonaws.com/'
+TEST_ACCOUNT = '123456789012'
+ALICE = 'arn:aws:iam::123456789012:user/alice'
+BOB = 'arn:aws:iam::123456789012:user/bob'
+SSO_PRINCIPAL = ('arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/'
                  'AWSReservedSSO_Developer_abc123')
 
 REPO_ROOT = os.path.join(os.path.dirname(__file__), '..')
@@ -288,13 +287,15 @@ def test_trust_policy_requires_an_attributable_mfa_session():
     assert 'DurationSeconds' not in _flat(trust)
 
 
-def test_session_duration_is_bounded_and_shorter_for_remediation():
+def test_session_duration_uses_the_minimum_valid_iam_ceiling():
     template = _build_template(**ENABLED_BOTH)
     diagnose = _role(template, C4IAM.DIAGNOSE_ROLE)
     remediate = _role(template, C4IAM.REMEDIATE_ROLE)
     assert diagnose['MaxSessionDuration'] == 3600
-    assert remediate['MaxSessionDuration'] == 1800
-    assert remediate['MaxSessionDuration'] < diagnose['MaxSessionDuration']
+    assert remediate['MaxSessionDuration'] == 3600
+    # IAM cannot enforce the recommended caller-requested 1800-second remediation session.
+    for role in (diagnose, remediate):
+        assert 3600 <= role['MaxSessionDuration'] <= 43200
 
 
 def test_mfa_condition_can_be_dropped_for_sso_accounts_without_losing_attribution():
@@ -318,18 +319,19 @@ def test_mfa_condition_can_be_dropped_for_sso_accounts_without_losing_attributio
 # ---------------------------------------------------------------------------------------------
 
 @pytest.mark.parametrize('logical_id', BOTH_ROLES)
-def test_wildcard_resources_appear_only_in_the_unscopable_read_statements(logical_id):
-    """ A bare "*" resource is permitted only where AWS offers no resource-level authorization for
-        the actions involved. Those statements are named, read-only and region-pinned.
+def test_wildcard_resources_appear_only_in_discovery_inspection_statements(logical_id):
+    """ Wildcard inspection is explicit, region-pinned, and owner-restricted when AWS supplies
+        resource context. A Sid alone is not proof that an API cannot support ARN scoping.
     """
     role = _role(_build_template(**ENABLED_BOTH), logical_id)
     for statement in _allows(role):
         if '*' in _resources(statement):
-            assert statement['Sid'] in C4IAM.UNSCOPABLE_READ_SIDS, (
+            assert statement['Sid'] in C4IAM.WILDCARD_READ_SIDS, (
                 f"{logical_id} statement {statement['Sid']!r} uses Resource '*' but is not one of"
-                f" the declared unscopable read statements")
+                f" the declared wildcard inspection statements")
             assert statement['Condition'] == {
-                'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
+                'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}},
+                'StringEqualsIfExists': {'aws:ResourceAccount': {'Ref': 'AWS::AccountId'}}}
 
 
 @pytest.mark.parametrize('logical_id', BOTH_ROLES)
@@ -338,7 +340,7 @@ def test_every_other_allow_is_scoped_to_a_service_level_arn(logical_id):
         and region), with a trailing wildcard standing in for "every resource of this type".
     """
     role = _role(_build_template(**ENABLED_BOTH), logical_id)
-    scoped = [s for s in _allows(role) if s['Sid'] not in C4IAM.UNSCOPABLE_READ_SIDS]
+    scoped = [s for s in _allows(role) if s['Sid'] not in C4IAM.WILDCARD_READ_SIDS]
     assert scoped, f'{logical_id} has no resource-scoped statements'
     for statement in scoped:
         for resource in _resources(statement):
@@ -364,7 +366,7 @@ def test_diagnostic_resource_scopes_are_service_level_for_each_supported_service
         'InspectBuildsAndWorkflows': ['arn:aws:codebuild:<region>:<account-id>:project/*'],
         'InspectWorkflowExecutions': ['arn:aws:states:<region>:<account-id>:*'],
         'InspectKeyMetadata': ['arn:aws:kms:<region>:<account-id>:key/*'],
-        'InspectOwnRoleDefinition': ['arn:aws:iam::<account-id>:role/*'],
+        'InspectAccountRoleDefinitions': ['arn:aws:iam::<account-id>:role/*'],
     }
     actual = {s['Sid']: [_render(r) for r in _resources(s)]
               for s in _allows(diagnose) if s['Sid'] in expected}
@@ -379,7 +381,7 @@ def test_remediation_resource_scopes_are_service_level_for_each_action():
         'ReleaseInFlightQueueMessages': ['arn:aws:sqs:<region>:<account-id>:*'],
         'StartWorkflowExecutions': ['arn:aws:states:<region>:<account-id>:stateMachine:*'],
         'StopWorkflowExecutions': ['arn:aws:states:<region>:<account-id>:execution:*'],
-        'RebuildApplicationImageViaCiOnly': ['arn:aws:codebuild:<region>:<account-id>:project/*'],
+        'DelegateBuildsToExistingServiceRoles': ['arn:aws:codebuild:<region>:<account-id>:project/*'],
     }
     actual = {s['Sid']: [_render(r) for r in _resources(s)]
               for s in _allows(remediate) if s['Sid'] in expected}
@@ -408,7 +410,7 @@ def test_no_role_ever_grants_action_star_or_a_service_wide_wildcard(logical_id):
             assert action != '*', f"{logical_id} grants Action '*'"
             assert not re.fullmatch(r'[a-z0-9-]+:\*', action), (
                 f'{logical_id} grants the service-wide wildcard {action!r}')
-    rendered = _flat(role['Policies'])
+    rendered = _flat(_allows(role))
     for blanket in ('"ecs:*"', '"es:*"', '"sqs:*"', '"s3:*"', '"elasticloadbalancing:*"'):
         assert blanket not in rendered, f'{logical_id} grants {blanket}'
 
@@ -453,20 +455,23 @@ def test_remediation_grants_exactly_the_intended_operational_actions():
     """ The mutating surface is small and closed - nothing creeps in unnoticed. """
     remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
     mutating = {action
-                for statement in _allows(remediate)
-                if statement['Sid'] not in C4IAM.UNSCOPABLE_READ_SIDS
+                for policy in remediate['Policies']
+                if policy['PolicyName'] == 'HumanRemediateActionPolicy'
+                for statement in policy['PolicyDocument']['Statement']
                 for action in _actions(statement)}
     assert mutating == REMEDIATION_ACTIONS
 
 
 @pytest.mark.parametrize('action', sorted(REMEDIATION_ACTIONS))
-def test_every_remediation_action_is_region_pinned_and_mfa_gated(action):
+def test_every_remediation_action_is_region_pinned_without_unavailable_mfa_context(action):
     remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
     allowing = _statements_allowing(remediate, action)
     assert len(allowing) == 1
     condition = allowing[0]['Condition']
-    assert condition['Bool'] == {'aws:MultiFactorAuthPresent': 'true'}
-    assert condition['StringEquals'] == {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}
+    assert condition == {'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
+    # MFA belongs in the trust policy. AssumeRole credentials do not retain API MFA context.
+    trust = remediate['AssumeRolePolicyDocument']['Statement'][0]['Condition']
+    assert trust['Bool'] == {'aws:MultiFactorAuthPresent': 'true'}
 
 
 def test_irreversible_and_destructive_operations_are_excluded_from_remediation():
@@ -579,7 +584,7 @@ def test_boundary_forbids_identity_infrastructure_and_destructive_operations():
         'PolicyDocument']
     denied = {action for s in document['Statement'] if s['Effect'] == 'Deny'
               for action in _actions(s)}
-    for action in ('iam:Create*', 'iam:Attach*', 'iam:PassRole', 'sso-admin:*', 'organizations:*',
+    for action in ('iam:Create*', 'iam:Attach*', 'iam:PassRole', 'sso:*', 'organizations:*',
                    'cloudformation:UpdateStack', 'cloudformation:ExecuteChangeSet',
                    'ecr:PutImage', 'lambda:UpdateFunctionCode', 'ec2:AuthorizeSecurityGroup*',
                    'sqs:PurgeQueue', 'sqs:DeleteQueue', 'rds:Delete*', 's3:PutObject*'):
@@ -662,11 +667,20 @@ def test_readme_policy_example_is_valid_and_well_formed(logical_id):
 def test_readme_policy_example_matches_what_the_template_renders(logical_id):
     """ Makes "aligned with the generated policy" a fact rather than a claim.
 
-        Compared by {Sid: sorted(actions)}: resources are deliberately not compared, because the
-        README uses <region>/<account-id> placeholders where the template emits Ref intrinsics.
+        Compare resources and conditions too, resolving pseudo-parameters to the same placeholders.
+        Action-only equality previously missed broken MFA gates and cross-account S3 reads.
     """
-    generated = _action_map(_role(_build_template(**ENABLED_BOTH), logical_id))
-    documented = {s['Sid']: sorted(_actions(s)) for s in _readme_policy(logical_id)['Statement']}
+    def render(value):
+        if isinstance(value, dict):
+            if 'Ref' in value or 'Fn::Join' in value:
+                return _render(value)
+            return {key: render(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [render(item) for item in value]
+        return value
+
+    generated = render(_statements(_role(_build_template(**ENABLED_BOTH), logical_id)))
+    documented = _readme_policy(logical_id)['Statement']
     assert documented == generated
 
 

--- a/tests/test_human_access_roles.py
+++ b/tests/test_human_access_roles.py
@@ -1,28 +1,32 @@
 """
 Static/template tests for the opt-in human direct-AWS-access roles built by C4IAM.
 
-These roles exist so a developer can inspect the running system, and a power user can perform a
-small number of named, reversible operational writes, without assuming the existing DevRole
+These roles exist so a developer can inspect the running system, and a power user can perform the
+reversible operational actions needed to remediate it, without assuming the existing DevRole
 (which is trusted by the account root and holds ten full-access managed policies).
 
-What is pinned here, in the order the requirements were stated:
+The scoping model these tests pin: the account holds only our own resources, so the policies do
+*not* enumerate resource identifiers. Where an action supports resource-level authorization it is
+scoped to the service (`arn:aws:ecs:<region>:<account>:service/*`, `arn:aws:s3:::*/*`, ...); where
+an action has no resource-level authorization at all, the resource is `"*"` and the statement is
+region-pinned instead. The constraint that carries the weight is therefore the *action list*, which
+is fully enumerated - so these tests check that list closely.
 
-  1. Disabled by default. With none of the human_access.* settings present, the IAM template is
-     exactly what it was before - same resources, same outputs, no CloudFormation Parameters and
-     no Conditions. A role is also not created when it is enabled but no approved principal ARNs
-     were supplied, because the alternative (account-root trust) is the thing being fixed.
-  2. Trust is restricted to enumerated principal ARNs with an attributable session, never to
-     arn:aws:iam::<account>:root.
-  3. The diagnostic role keeps resource-scoped Secrets Manager and S3 object reads, plus the
-     observability reads needed to inspect services - and nothing on '*' that mutates.
-  4. Broad privilege is denied: no managed policies at all, no supply-chain or identity writes,
-     and every remediation write is on an explicitly supplied ARN.
+Covered here, in the order the requirements were stated:
 
-Physical identifiers asserted here are derived the same way the rest of the repo derives them
-(names.py for secrets, base.py bucket templates, C4Logging's stack name for log groups), so these
-tests fail if that derivation drifts rather than encoding a second guess at the real names.
+  1. Disabled-default behaviour - no resources, outputs, parameters or conditions added.
+  2. Trust restrictions - enumerated principal ARNs, attributable session, never account root.
+  3. Service-level resource scope - and `"*"` only in the two statements whose actions AWS gives
+     no ARN to scope to.
+  4. Constrained allowed actions - every action enumerated, no `service:*` and no `"*"`.
+  5. Prohibited broad administration - no managed policies, and the administrative/destructive
+     actions are explicitly denied.
+  6. The README's illustrative JSON matches what the template actually renders.
 """
+import io
 import json
+import os
+import re
 from unittest import mock
 
 import pytest
@@ -32,7 +36,6 @@ from src.constants import Settings
 from src.part import C4Tags, C4Account
 from src.parts import iam as iam_mod
 from src.parts.iam import C4IAM
-from src.parts.logging import C4Logging
 from troposphere import Template
 
 
@@ -42,13 +45,9 @@ ALICE = 'arn:aws:iam::123456789:user/alice'
 BOB = 'arn:aws:iam::123456789:user/bob'
 SSO_PRINCIPAL = ('arn:aws:iam::123456789:role/aws-reserved/sso.amazonaws.com/'
                  'AWSReservedSSO_Developer_abc123')
-TEST_KMS_KEY_ID = '27d040a3-ead1-4f5a-94ce-0fa6e7f84a95'
 
-SERVICE_ARN = 'arn:aws:ecs:us-east-1:123456789:service/some-cluster/portal'
-CLUSTER_ARN = 'arn:aws:ecs:us-east-1:123456789:cluster/some-cluster'
-QUEUE_ARN = 'arn:aws:sqs:us-east-1:123456789:cgap-build-indexer'
-STATE_MACHINE_ARN = 'arn:aws:states:us-east-1:123456789:stateMachine:tibanna_unicorn'
-CODEBUILD_ARN = 'arn:aws:codebuild:us-east-1:123456789:project/main-build'
+REPO_ROOT = os.path.join(os.path.dirname(__file__), '..')
+README = os.path.join(REPO_ROOT, 'README.md')
 
 # The IAM stack as it stands before any of this is enabled.
 PRE_EXISTING_RESOURCES = {
@@ -66,6 +65,7 @@ PRE_EXISTING_OUTPUTS = {
     'C4IAMMainECSInstanceProfile',
     'C4IAMMainECSS3IAMUser',
 }
+BOUNDARY_ID = 'C4IAMMainHumanAccessBoundary'
 
 BASE_CONFIG = {
     Settings.APP_KIND: 'cgap',
@@ -74,20 +74,13 @@ BASE_CONFIG = {
 }
 _MISSING = object()
 
-# Everything needed to actually get both roles built.
 ENABLED_BOTH = {
     Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED: True,
     Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: f'{ALICE}, {BOB}',
     Settings.HUMAN_ACCESS_REMEDIATE_ENABLED: True,
     Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS: ALICE,
 }
-REMEDIATION_TARGETS = {
-    Settings.HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS: SERVICE_ARN,
-    Settings.HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS: CLUSTER_ARN,
-    Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS: QUEUE_ARN,
-    Settings.HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS: STATE_MACHINE_ARN,
-    Settings.HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS: CODEBUILD_ARN,
-}
+BOTH_ROLES = (C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE)
 
 
 def _make_iam_part() -> C4IAM:
@@ -128,14 +121,24 @@ def _statements(role_properties: dict) -> list:
             for statement in policy['PolicyDocument']['Statement']]
 
 
+def _as_list(value) -> list:
+    return value if isinstance(value, list) else [value]
+
+
 def _actions(statement: dict) -> list:
-    actions = statement.get('Action', statement.get('NotAction', []))
-    return actions if isinstance(actions, list) else [actions]
+    return _as_list(statement.get('Action', statement.get('NotAction', [])))
+
+
+def _resources(statement: dict) -> list:
+    return _as_list(statement.get('Resource', statement.get('NotResource', [])))
+
+
+def _allows(role_properties: dict) -> list:
+    return [s for s in _statements(role_properties) if s['Effect'] == 'Allow']
 
 
 def _statements_allowing(role_properties: dict, action: str) -> list:
-    return [s for s in _statements(role_properties)
-            if s['Effect'] == 'Allow' and action in _actions(s)]
+    return [s for s in _allows(role_properties) if action in _actions(s)]
 
 
 def _denied_actions(role_properties: dict) -> set:
@@ -145,17 +148,39 @@ def _denied_actions(role_properties: dict) -> set:
             for action in _actions(statement)}
 
 
-def _resources(statement: dict) -> list:
-    resources = statement.get('Resource', statement.get('NotResource', []))
-    return resources if isinstance(resources, list) else [resources]
+def _render(value) -> str:
+    """ Renders a resource entry - possibly an Fn::Join over CloudFormation pseudo-parameters -
+        into a comparable string, so a service-level ARN can be asserted on directly.
+    """
+    if isinstance(value, dict):
+        if 'Fn::Join' in value:
+            separator, parts = value['Fn::Join']
+            return separator.join(_render(part) for part in parts)
+        if value == {'Ref': 'AWS::Region'}:
+            return '<region>'
+        if value == {'Ref': 'AWS::AccountId'}:
+            return '<account-id>'
+    return str(value)
 
 
 def _flat(value) -> str:
     return json.dumps(value, sort_keys=True)
 
 
+def _action_map(role_properties: dict) -> dict:
+    """ {Sid: sorted(actions)} across all of a role's inline policies. This is the shape compared
+        against the README, and it stays stable under resource/condition changes.
+    """
+    result = {}
+    for statement in _statements(role_properties):
+        sid = statement['Sid']
+        assert sid not in result, f'duplicate Sid {sid!r}'
+        result[sid] = sorted(_actions(statement))
+    return result
+
+
 # ---------------------------------------------------------------------------------------------
-# 1. Disabled by default
+# 1. Disabled-default behaviour
 # ---------------------------------------------------------------------------------------------
 
 def test_human_access_roles_are_absent_by_default():
@@ -210,22 +235,32 @@ def test_each_role_can_be_enabled_independently():
     assert C4IAM.DIAGNOSE_ROLE not in template['Resources']
 
 
+def test_enabled_template_adds_only_the_expected_resources():
+    template = _build_template(**ENABLED_BOTH)
+    assert set(template['Resources']) - PRE_EXISTING_RESOURCES == {
+        C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE, BOUNDARY_ID}
+    added_outputs = set(template['Outputs']) - PRE_EXISTING_OUTPUTS
+    assert added_outputs == {f'C4IAMMain{C4IAM.DIAGNOSE_ROLE}Name',
+                             f'C4IAMMain{C4IAM.REMEDIATE_ROLE}Name'}
+    # The opt-in outputs are not exported: no other stack should depend on this feature.
+    for output in added_outputs:
+        assert 'Export' not in template['Outputs'][output]
+
+
 # ---------------------------------------------------------------------------------------------
 # 2. Trust restrictions
 # ---------------------------------------------------------------------------------------------
 
-@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
 def test_trust_policy_never_trusts_the_account_root(logical_id):
-    template = _build_template(**ENABLED_BOTH)
-    trust = _flat(_role(template, logical_id)['AssumeRolePolicyDocument'])
+    trust = _flat(_role(_build_template(**ENABLED_BOTH), logical_id)['AssumeRolePolicyDocument'])
     assert 'AWS::AccountId' not in trust
     assert ':root' not in trust
 
 
 def test_trust_policy_pins_exactly_the_supplied_principals():
     template = _build_template(**ENABLED_BOTH)
-    diagnose_trust = _role(template, C4IAM.DIAGNOSE_ROLE)['AssumeRolePolicyDocument']
-    allow = diagnose_trust['Statement'][0]
+    allow = _role(template, C4IAM.DIAGNOSE_ROLE)['AssumeRolePolicyDocument']['Statement'][0]
     assert allow['Effect'] == 'Allow'
     assert allow['Principal'] == {'AWS': [ALICE, BOB]}
     assert '*' not in allow['Principal']['AWS']
@@ -275,330 +310,175 @@ def test_mfa_condition_can_be_dropped_for_sso_accounts_without_losing_attributio
     assert 'MultiFactorAuthPresent' not in _flat(trust)
     assert trust['Statement'][0]['Principal'] == {'AWS': [SSO_PRINCIPAL]}
     assert trust['Statement'][1]['Condition'] == {'Null': {'sts:SourceIdentity': 'true'}}
-    # Not a back door to account-root trust.
     assert 'AWS::AccountId' not in _flat(trust)
 
 
 # ---------------------------------------------------------------------------------------------
-# 3. Approved diagnostic reads
+# 3. Service-level resource scope
 # ---------------------------------------------------------------------------------------------
 
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_wildcard_resources_appear_only_in_the_unscopable_read_statements(logical_id):
+    """ A bare "*" resource is permitted only where AWS offers no resource-level authorization for
+        the actions involved. Those statements are named, read-only and region-pinned.
+    """
+    role = _role(_build_template(**ENABLED_BOTH), logical_id)
+    for statement in _allows(role):
+        if '*' in _resources(statement):
+            assert statement['Sid'] in C4IAM.UNSCOPABLE_READ_SIDS, (
+                f"{logical_id} statement {statement['Sid']!r} uses Resource '*' but is not one of"
+                f" the declared unscopable read statements")
+            assert statement['Condition'] == {
+                'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_every_other_allow_is_scoped_to_a_service_level_arn(logical_id):
+    """ Service-level, not identifier-level: an ARN naming the service (and normally this account
+        and region), with a trailing wildcard standing in for "every resource of this type".
+    """
+    role = _role(_build_template(**ENABLED_BOTH), logical_id)
+    scoped = [s for s in _allows(role) if s['Sid'] not in C4IAM.UNSCOPABLE_READ_SIDS]
+    assert scoped, f'{logical_id} has no resource-scoped statements'
+    for statement in scoped:
+        for resource in _resources(statement):
+            rendered = _render(resource)
+            assert rendered.startswith('arn:aws:'), rendered
+            assert '*' in rendered, f'{rendered} is not service-level scoped'
+            # S3 ARNs carry neither region nor account; everything else must carry both.
+            if not rendered.startswith('arn:aws:s3:::'):
+                assert '<account-id>' in rendered, rendered
+
+
+def test_diagnostic_resource_scopes_are_service_level_for_each_supported_service():
+    """ Pins the actual scope of each read that AWS lets us attach an ARN to. """
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    expected = {
+        'ReadApplicationLogs': ['arn:aws:logs:<region>:<account-id>:log-group:*',
+                                'arn:aws:logs:<region>:<account-id>:log-group:*:log-stream:*'],
+        'InspectBucketConfiguration': ['arn:aws:s3:::*'],
+        'ReadObjects': ['arn:aws:s3:::*/*'],
+        'ReadSecrets': ['arn:aws:secretsmanager:<region>:<account-id>:secret:*'],
+        'InspectQueueDepth': ['arn:aws:sqs:<region>:<account-id>:*'],
+        'InspectContainerImages': ['arn:aws:ecr:<region>:<account-id>:repository/*'],
+        'InspectBuildsAndWorkflows': ['arn:aws:codebuild:<region>:<account-id>:project/*'],
+        'InspectWorkflowExecutions': ['arn:aws:states:<region>:<account-id>:*'],
+        'InspectKeyMetadata': ['arn:aws:kms:<region>:<account-id>:key/*'],
+        'InspectOwnRoleDefinition': ['arn:aws:iam::<account-id>:role/*'],
+    }
+    actual = {s['Sid']: [_render(r) for r in _resources(s)]
+              for s in _allows(diagnose) if s['Sid'] in expected}
+    assert actual == expected
+
+
+def test_remediation_resource_scopes_are_service_level_for_each_action():
+    remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
+    expected = {
+        'RestartOrRescaleServices': ['arn:aws:ecs:<region>:<account-id>:service/*'],
+        'StopStuckTasks': ['arn:aws:ecs:<region>:<account-id>:task/*'],
+        'ReleaseInFlightQueueMessages': ['arn:aws:sqs:<region>:<account-id>:*'],
+        'StartWorkflowExecutions': ['arn:aws:states:<region>:<account-id>:stateMachine:*'],
+        'StopWorkflowExecutions': ['arn:aws:states:<region>:<account-id>:execution:*'],
+        'RebuildApplicationImageViaCiOnly': ['arn:aws:codebuild:<region>:<account-id>:project/*'],
+    }
+    actual = {s['Sid']: [_render(r) for r in _resources(s)]
+              for s in _allows(remediate) if s['Sid'] in expected}
+    assert actual == expected
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_no_resource_identifiers_are_baked_into_the_policies(logical_id):
+    """ Service-level scope means no env name, bucket name or queue name should appear at all. """
+    rendered = _flat(_role(_build_template(**ENABLED_BOTH), logical_id)['Policies'])
+    for token in (TEST_ENV_NAME, 'C4AppConfig', 'C4Datastore', 'application-files',
+                  'foursight', 'c4-logging'):
+        assert token not in rendered, f'{token!r} is a resource identifier and should not appear'
+
+
+# ---------------------------------------------------------------------------------------------
+# 4. Constrained allowed actions
+# ---------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_no_role_ever_grants_action_star_or_a_service_wide_wildcard(logical_id):
+    """ The action list is the real constraint, so it must be fully enumerated. """
+    role = _role(_build_template(**ENABLED_BOTH), logical_id)
+    for statement in _allows(role):
+        for action in _actions(statement):
+            assert action != '*', f"{logical_id} grants Action '*'"
+            assert not re.fullmatch(r'[a-z0-9-]+:\*', action), (
+                f'{logical_id} grants the service-wide wildcard {action!r}')
+    rendered = _flat(role['Policies'])
+    for blanket in ('"ecs:*"', '"es:*"', '"sqs:*"', '"s3:*"', '"elasticloadbalancing:*"'):
+        assert blanket not in rendered, f'{logical_id} grants {blanket}'
+
+
 DIAGNOSTIC_READS = [
-    'ecs:Describe*',                # is the portal up, why did a task die
-    'ecs:List*',
-    'elasticloadbalancing:Describe*',  # are target groups healthy
-    'cloudwatch:Get*',              # is RDS saturated, is OpenSearch red
-    'logs:Describe*',
-    'rds:Describe*',
-    'sqs:GetQueueAttributes',       # is indexing backed up (depth, not message bodies)
-    'cloudformation:Describe*',     # did the last deploy succeed
-    'ecr:Describe*',                # which image is actually running
-    'es:Describe*',
-    'ec2:Describe*',
+    'ecs:DescribeServices',          # is the portal up
+    'ecs:DescribeTasks',             # why did a task die
+    'elasticloadbalancing:DescribeTargetHealth',
+    'cloudwatch:GetMetricData',      # is RDS saturated, is OpenSearch red
+    'logs:FilterLogEvents',          # what is the stack trace
+    'logs:StartQuery',
+    'rds:DescribeDBInstances',
+    'sqs:GetQueueAttributes',        # is indexing backed up (depth, not bodies)
+    'cloudformation:DescribeStackEvents',
+    'ecr:DescribeImages',            # which image is actually running
+    'es:DescribeDomain',
+    'secretsmanager:GetSecretValue',  # retained, resource-scoped, per captain decision
+    's3:GetObject',
 ]
 
 
 @pytest.mark.parametrize('action', DIAGNOSTIC_READS)
-def test_diagnostic_role_allows_the_approved_observability_reads(action):
+def test_diagnostic_role_allows_the_distinct_reads_the_services_require(action):
     diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
-    allowing = _statements_allowing(diagnose, action)
-    assert allowing, f'{action} is not allowed to the diagnostic role'
-    # These APIs have no resource-level authorization, so they are on '*' but region-pinned.
-    for statement in allowing:
-        assert statement['Condition'] == {'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
+    assert _statements_allowing(diagnose, action), f'{action} is not allowed'
+    assert action not in _denied_actions(diagnose), f'{action} is both allowed and denied'
 
 
-def test_diagnostic_role_can_read_application_logs_scoped_to_this_deployment():
-    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
-    allowing = _statements_allowing(diagnose, 'logs:FilterLogEvents')
-    assert len(allowing) == 1
-    resources = _resources(allowing[0])
-    rendered = _flat(resources)
-    # Log groups have no LogGroupName, so their physical names are CloudFormation-generated and
-    # can only be matched by the logging stack's prefix. Derive it rather than restating it.
-    assert f'{C4Logging.suggest_stack_name().stack_name}-*' in rendered
-    assert f'/aws/rds/instance/rds-{TEST_ENV_NAME}/*' in rendered
-    # Every ARN is a scoped Fn::Join, never a bare '*' matching every log group in the account.
-    # (A '*' does appear inside them as the log-stream segment, which is expected.)
-    assert resources and all(resource != '*' for resource in resources)
+REMEDIATION_ACTIONS = {
+    'ecs:UpdateService',            # restart / rescale
+    'ecs:StopTask',                 # kill one stuck task
+    'sqs:ChangeMessageVisibility',  # release in-flight messages
+    'states:StartExecution',        # rerun a stuck workflow
+    'states:StopExecution',
+    'codebuild:StartBuild',         # rebuild through CI
+    'codebuild:StopBuild',
+    'codebuild:RetryBuild',
+}
 
 
-def test_diagnostic_secret_reads_are_retained_but_resource_scoped():
-    """ Captain decision: developers keep direct Secrets Manager reads, scoped to the application's
-        own secrets, so they can inspect the system and bring evidence.
-    """
-    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
-    allowing = _statements_allowing(diagnose, 'secretsmanager:GetSecretValue')
-    assert allowing, 'the diagnostic role must retain GetSecretValue'
-    assert len(allowing) == 1
-    resources = _flat(_resources(allowing[0]))
-    # The real secret names, per names.py: the app configuration (GAC) and the RDS master secret.
-    assert 'C4AppConfigCgapBuild' in resources
-    assert 'C4DatastoreCgapBuildRDSSecret' in resources
-    # Never the ECS role's unscoped grant.
-    assert '"*"' not in resources
-    assert 'GetSecretValue' not in _denied_actions(diagnose)
-
-
-def test_diagnostic_object_reads_are_retained_but_scoped_to_application_buckets():
-    """ Same decision for S3 objects: kept, but only in this deployment's own buckets. """
-    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
-    allowing = _statements_allowing(diagnose, 's3:GetObject')
-    assert allowing, 'the diagnostic role must retain s3:GetObject'
-    assert len(allowing) == 1
-    resources = _resources(allowing[0])
-    assert resources, 'no buckets were scoped'
-    for resource in resources:
-        assert resource.startswith(f'arn:aws:s3:::{TEST_ENV_NAME}-'), resource
-        assert resource.endswith('/*'), resource
-    # Derived from base.py's bucket templates, so the real application buckets are covered.
-    assert f'arn:aws:s3:::{TEST_ENV_NAME}-application-files/*' in resources
-    assert f'arn:aws:s3:::{TEST_ENV_NAME}-application-wfoutput/*' in resources
-    assert 's3:GetObject' not in _denied_actions(diagnose)
-
-
-def test_diagnostic_bucket_list_can_be_supplied_explicitly_for_legacy_names():
-    """ Not every environment's buckets follow the derived pattern, so the list is overridable. """
-    diagnose = _role(_build_template(**dict(ENABLED_BOTH, **{
-        Settings.HUMAN_ACCESS_DIAGNOSE_BUCKETS: 'foursight-prod-envs, legacy-application-files',
-    })), C4IAM.DIAGNOSE_ROLE)
-    resources = _resources(_statements_allowing(diagnose, 's3:GetObject')[0])
-    assert resources == ['arn:aws:s3:::foursight-prod-envs/*',
-                         'arn:aws:s3:::legacy-application-files/*']
-
-
-def test_kms_decrypt_is_off_by_default_and_scoped_to_the_configured_key_when_enabled():
-    with_key = dict(ENABLED_BOTH, **{Settings.S3_ENCRYPT_KEY_ID: TEST_KMS_KEY_ID})
-
-    # Off by default: metadata only, and Decrypt is explicitly denied.
-    diagnose = _role(_build_template(**with_key), C4IAM.DIAGNOSE_ROLE)
-    assert not _statements_allowing(diagnose, 'kms:Decrypt')
-    assert 'kms:Decrypt' in _denied_actions(diagnose)
-    assert _statements_allowing(diagnose, 'kms:DescribeKey')
-    # The more revealing key-policy read is scoped to the configured key.
-    key_policy_reads = _statements_allowing(diagnose, 'kms:GetKeyPolicy')
-    assert len(key_policy_reads) == 1
-    assert f'key/{TEST_KMS_KEY_ID}' in _flat(_resources(key_policy_reads[0]))
-
-    # Enabled: allowed on exactly the one configured key, never '*', and no longer denied.
-    diagnose = _role(_build_template(**dict(
-        with_key, **{Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True})), C4IAM.DIAGNOSE_ROLE)
-    allowing = _statements_allowing(diagnose, 'kms:Decrypt')
-    assert len(allowing) == 1
-    resources = _flat(_resources(allowing[0]))
-    assert f'key/{TEST_KMS_KEY_ID}' in resources
-    assert '"*"' not in resources
-    assert 'kms:Decrypt' not in _denied_actions(diagnose)
-
-
-def test_no_key_material_access_without_a_configured_key_but_metadata_still_readable():
-    """ Never a '*' fallback for Decrypt or for the key-policy read when s3.encrypt_key_id is
-        unset - which is the common case, only smaht-wolf configures one. Plain key metadata stays
-        available so "is this bucket encrypted, and with which key" remains answerable.
-    """
-    diagnose = _role(_build_template(**dict(ENABLED_BOTH, **{
-        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True})), C4IAM.DIAGNOSE_ROLE)
-    assert not _statements_allowing(diagnose, 'kms:Decrypt')
-    assert not _statements_allowing(diagnose, 'kms:GetKeyPolicy')
-
-    metadata_reads = _statements_allowing(diagnose, 'kms:DescribeKey')
-    assert len(metadata_reads) == 1
-    # Metadata only, and region-pinned: no key material, no ciphertext, no key policy.
-    assert metadata_reads[0]['Condition'] == {
-        'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
-    granted = set(_actions(metadata_reads[0]))
-    assert not granted & {'kms:Decrypt', 'kms:GenerateDataKey', 'kms:ReEncryptFrom',
-                          'kms:GetKeyPolicy', 'kms:CreateGrant'}
-
-
-# ---------------------------------------------------------------------------------------------
-# 4. Denied broad privilege
-# ---------------------------------------------------------------------------------------------
-
-@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
-def test_neither_role_attaches_any_managed_policy(logical_id):
-    """ The ten managed policies on DevRole are what make it a superset of the runtime role. """
-    role = _role(_build_template(**ENABLED_BOTH), logical_id)
-    assert 'ManagedPolicyArns' not in role
-    assert 'arn:aws:iam::aws:policy/' not in _flat(role)
-
-
-@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
-def test_both_roles_carry_the_permission_boundary(logical_id):
-    template = _build_template(**ENABLED_BOTH)
-    role = _role(template, logical_id)
-    boundary_id = 'C4IAMMainHumanAccessBoundary'
-    assert template['Resources'][boundary_id]['Type'] == 'AWS::IAM::ManagedPolicy'
-    assert role['PermissionsBoundary'] == {'Ref': boundary_id}
-
-
-# Privileges neither human role may hold, each tied to why it matters.
-FORBIDDEN_ACTIONS = [
-    'ecr:PutImage',                 # authoring image content is CI's job, not a human's
-    'ecr:InitiateLayerUpload',
-    'ecs:RegisterTaskDefinition',   # no new task definitions
-    'ecs:RunTask',
-    'ecs:ExecuteCommand',           # no shell inside a running container
-    'iam:PassRole',
-    'sts:GetFederationToken',       # the S3 federator's escape hatch
-    'sts:AssumeRole',               # no chaining into another role
-]
-
-
-@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
-@pytest.mark.parametrize('action', FORBIDDEN_ACTIONS)
-def test_broad_privilege_is_explicitly_denied_on_both_roles(logical_id, action):
-    role = _role(_build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS)), logical_id)
-    assert action in _denied_actions(role), f'{action} is not denied on {logical_id}'
-    assert not _statements_allowing(role, action)
-
-
-def test_diagnostic_role_is_read_only():
-    """ Every write the remediation role may do is denied here, so the two are not interchangeable.
-    """
-    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
-    denied = _denied_actions(diagnose)
-    for action in ('ecs:UpdateService', 'ecs:StopTask', 'sqs:PurgeQueue', 'codebuild:StartBuild',
-                   'states:StartExecution', 's3:PutObject', 's3:DeleteObject',
-                   'secretsmanager:PutSecretValue', 'cloudwatch:PutMetricAlarm'):
-        assert action in denied, f'{action} is not denied to the read-only role'
-    # Data-plane and configuration exfiltration paths that a read-only role must not have.
-    for action in ('sqs:ReceiveMessage', 'rds:DownloadCompleteDBLogFile',
-                   'lambda:GetFunctionConfiguration', 'ssm:GetParameter'):
-        assert action in denied, f'{action} is not denied to the read-only role'
-
-
-def test_no_mutating_action_is_ever_granted_on_a_wildcard_resource():
-    template = _build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS))
-    mutating_verbs = ('Update', 'Delete', 'Create', 'Put', 'Purge', 'Start', 'Stop', 'Retry',
-                      'Register', 'Run', 'Execute', 'Modify', 'Restore', 'Reboot')
-    read_only_exceptions = {'logs:StartQuery', 'logs:StopQuery', 'sts:GetCallerIdentity'}
-    for logical_id in (C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE):
-        for statement in _statements(_role(template, logical_id)):
-            if statement['Effect'] != 'Allow':
-                continue
-            for action in _actions(statement):
-                if action in read_only_exceptions or not any(v in action for v in mutating_verbs):
-                    continue
-                assert '*' not in _resources(statement), (
-                    f'{logical_id} grants {action} on a wildcard resource')
-
-
-def test_boundary_bounds_the_scoped_reads_instead_of_dropping_the_deny():
-    """ The boundary opens with Allow *:*, so simply removing s3:GetObject / GetSecretValue from
-        its deny list would permit them on everything. They are denied via NotResource instead.
-    """
-    template = _build_template(**dict(ENABLED_BOTH, **{
-        Settings.S3_ENCRYPT_KEY_ID: TEST_KMS_KEY_ID,
-        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True,
-    }))
-    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
-    carve_outs = {s['Sid']: s for s in boundary['Statement'] if 'NotResource' in s}
-    assert set(carve_outs) == {'BoundS3ObjectReadsToApplicationBuckets',
-                               'BoundSecretReadsToApplicationSecrets',
-                               'BoundKmsUseToConfiguredEncryptionKey'}
-    for statement in carve_outs.values():
-        assert statement['Effect'] == 'Deny'
-        assert statement['NotResource'], 'an empty NotResource would deny nothing'
-        assert '*' not in statement['NotResource']
-    assert 's3:GetObject' in _actions(carve_outs['BoundS3ObjectReadsToApplicationBuckets'])
-    assert 'secretsmanager:GetSecretValue' in _actions(
-        carve_outs['BoundSecretReadsToApplicationSecrets'])
-
-
-def test_boundary_denies_the_scoped_reads_outright_when_there_is_nothing_to_carve_out():
-    """ With no encryption key configured there is no legitimate target, so the deny is absolute. """
-    template = _build_template(**ENABLED_BOTH)
-    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
-    kms_deny = next(s for s in boundary['Statement']
-                    if s['Sid'] == 'BoundKmsUseToConfiguredEncryptionKey')
-    assert 'NotResource' not in kms_deny
-    assert kms_deny['Resource'] == '*'
-    assert kms_deny['Effect'] == 'Deny'
-
-
-def test_boundary_forbids_identity_and_infrastructure_administration():
-    template = _build_template(**ENABLED_BOTH)
-    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
-    denied = {action for s in boundary['Statement'] if s['Effect'] == 'Deny'
-              for action in _actions(s)}
-    for action in ('iam:Create*', 'iam:Attach*', 'iam:PassRole', 'sso-admin:*', 'organizations:*',
-                   'cloudformation:UpdateStack', 'cloudformation:ExecuteChangeSet',
-                   'ecr:PutImage', 'lambda:UpdateFunctionCode', 'ec2:AuthorizeSecurityGroup*'):
-        assert action in denied, f'boundary does not forbid {action}'
-    # It is a boundary, not an administrative grant: the only Allow is the standard Allow *:*
-    # that the deny statements then carve down.
-    allows = [s for s in boundary['Statement'] if s['Effect'] == 'Allow']
-    assert len(allows) == 1
-    assert allows[0]['Action'] == '*'
-
-
-# ---------------------------------------------------------------------------------------------
-# Remediation is narrowly parameterized
-# ---------------------------------------------------------------------------------------------
-
-def test_remediation_has_no_mutating_power_until_target_arns_are_supplied():
-    """ No derived-name, ENV_NAME or wildcard fallback: an unnamed environment is out of reach.
-        This is what keeps a live (green) environment out of scope unless it is named on purpose.
-    """
+def test_remediation_grants_exactly_the_intended_operational_actions():
+    """ The mutating surface is small and closed - nothing creeps in unnoticed. """
     remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
-    policy_names = [p['PolicyName'] for p in remediate['Policies']]
-    assert 'HumanRemediateActionPolicy' not in policy_names
-    for action in ('ecs:UpdateService', 'ecs:StopTask', 'sqs:ChangeMessageVisibility',
-                   'sqs:PurgeQueue', 'states:StartExecution', 'codebuild:StartBuild'):
-        assert not _statements_allowing(remediate, action), f'{action} granted with no target ARN'
-    assert TEST_ENV_NAME not in _flat(remediate['Policies'])
+    mutating = {action
+                for statement in _allows(remediate)
+                if statement['Sid'] not in C4IAM.UNSCOPABLE_READ_SIDS
+                for action in _actions(statement)}
+    assert mutating == REMEDIATION_ACTIONS
 
 
-@pytest.mark.parametrize('setting, action, expected_resource', [
-    (Settings.HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS, 'ecs:UpdateService', SERVICE_ARN),
-    (Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS, 'sqs:ChangeMessageVisibility', QUEUE_ARN),
-    (Settings.HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS, 'states:StartExecution',
-     STATE_MACHINE_ARN),
-    (Settings.HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS, 'codebuild:StartBuild', CODEBUILD_ARN),
-])
-def test_each_remediation_capability_is_driven_by_its_own_supplied_arns(
-        setting, action, expected_resource):
-    remediate = _role(_build_template(**dict(ENABLED_BOTH, **{setting: expected_resource})),
-                      C4IAM.REMEDIATE_ROLE)
+@pytest.mark.parametrize('action', sorted(REMEDIATION_ACTIONS))
+def test_every_remediation_action_is_region_pinned_and_mfa_gated(action):
+    remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
     allowing = _statements_allowing(remediate, action)
     assert len(allowing) == 1
-    assert _resources(allowing[0]) == [expected_resource]
-    # Every write is region-pinned and gated on a live MFA session.
     condition = allowing[0]['Condition']
     assert condition['Bool'] == {'aws:MultiFactorAuthPresent': 'true'}
     assert condition['StringEquals'] == {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}
 
 
-def test_stop_task_is_confined_to_the_supplied_cluster():
-    remediate = _role(_build_template(**dict(ENABLED_BOTH, **{
-        Settings.HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS: CLUSTER_ARN})), C4IAM.REMEDIATE_ROLE)
-    allowing = _statements_allowing(remediate, 'ecs:StopTask')
-    assert len(allowing) == 1
-    assert _resources(allowing[0]) == ['arn:aws:ecs:us-east-1:123456789:task/some-cluster/*']
-    assert allowing[0]['Condition']['ArnEquals'] == {'ecs:cluster': [CLUSTER_ARN]}
-
-
-def test_sqs_purge_requires_its_own_explicit_flag_on_top_of_supplied_queues():
-    """ PurgeQueue is irreversible, so having queue ARNs is not enough to get it. """
-    with_queues = dict(ENABLED_BOTH, **{Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS: QUEUE_ARN})
-
-    remediate = _role(_build_template(**with_queues), C4IAM.REMEDIATE_ROLE)
-    assert not _statements_allowing(remediate, 'sqs:PurgeQueue')
-    # The reversible queue action is still available, i.e. purge is genuinely split out.
+def test_irreversible_and_destructive_operations_are_excluded_from_remediation():
+    """ SQS purge is excluded outright - not an opt-in - and denied so it stays excluded. """
+    remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
+    denied = _denied_actions(remediate)
+    for action in ('sqs:PurgeQueue', 'sqs:DeleteQueue', 'sqs:DeleteMessage', 's3:DeleteObject',
+                   'ecs:DeleteService', 'ecs:DeleteCluster'):
+        assert not _statements_allowing(remediate, action), f'{action} must not be granted'
+        assert action in denied, f'{action} is not explicitly denied'
+    # The reversible alternative is what remediation gets instead.
     assert _statements_allowing(remediate, 'sqs:ChangeMessageVisibility')
-
-    remediate = _role(_build_template(**dict(with_queues, **{
-        Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE: True})), C4IAM.REMEDIATE_ROLE)
-    allowing = _statements_allowing(remediate, 'sqs:PurgeQueue')
-    assert len(allowing) == 1
-    assert _resources(allowing[0]) == [QUEUE_ARN]
-
-
-def test_purge_flag_alone_grants_nothing_without_queue_arns():
-    remediate = _role(_build_template(**dict(ENABLED_BOTH, **{
-        Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE: True})), C4IAM.REMEDIATE_ROLE)
-    assert not _statements_allowing(remediate, 'sqs:PurgeQueue')
 
 
 def test_remediation_reads_are_narrower_than_diagnostic_reads():
@@ -609,27 +489,104 @@ def test_remediation_reads_are_narrower_than_diagnostic_reads():
         assert action in _denied_actions(remediate)
 
 
+def test_diagnostic_role_is_read_only():
+    """ Every write the remediation role may do is denied here, so they are not interchangeable. """
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    denied = _denied_actions(diagnose)
+    for action in sorted(REMEDIATION_ACTIONS):
+        assert action in denied, f'{action} is not denied to the read-only role'
+    for action in ('s3:PutObject', 's3:DeleteObject', 'secretsmanager:PutSecretValue',
+                   'cloudwatch:PutMetricAlarm', 'sqs:PurgeQueue'):
+        assert action in denied, f'{action} is not denied to the read-only role'
+    # Data-plane and configuration exfiltration paths a read-only role must not have.
+    for action in ('sqs:ReceiveMessage', 'rds:DownloadCompleteDBLogFile',
+                   'lambda:GetFunctionConfiguration', 'ssm:GetParameter'):
+        assert action in denied, f'{action} is not denied to the read-only role'
+
+
+def test_kms_decrypt_is_off_by_default_and_opt_in_only():
+    """ At service scope Decrypt reaches every key in the account, so it keeps its own switch. """
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    assert not _statements_allowing(diagnose, 'kms:Decrypt')
+    assert not _statements_allowing(diagnose, 'kms:GetKeyPolicy')
+    assert 'kms:Decrypt' in _denied_actions(diagnose)
+    # Metadata stays available so bucket encryption is still diagnosable.
+    assert _statements_allowing(diagnose, 'kms:DescribeKey')
+
+    diagnose = _role(_build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True})), C4IAM.DIAGNOSE_ROLE)
+    allowing = _statements_allowing(diagnose, 'kms:Decrypt')
+    assert len(allowing) == 1
+    assert _render(_resources(allowing[0])[0]) == 'arn:aws:kms:<region>:<account-id>:key/*'
+    assert 'kms:Decrypt' not in _denied_actions(diagnose)
+
+
 # ---------------------------------------------------------------------------------------------
-# Structural guarantees
+# 5. Prohibited broad administration
 # ---------------------------------------------------------------------------------------------
 
-def test_human_roles_do_not_reuse_the_ecs_runtime_role_policies():
-    """ dev_user_role() shares four inline policy objects with the ECS runtime role, which is what
-        makes human access a superset of runtime privilege. These roles must not repeat that.
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_neither_role_attaches_any_managed_policy(logical_id):
+    """ The ten managed policies on DevRole are what make it a superset of the runtime role. """
+    role = _role(_build_template(**ENABLED_BOTH), logical_id)
+    assert 'ManagedPolicyArns' not in role
+    assert 'arn:aws:iam::aws:policy/' not in _flat(role)
+
+
+FORBIDDEN_ACTIONS = [
+    'ecr:PutImage',                 # authoring image content is CI's job, not a human's
+    'ecr:InitiateLayerUpload',
+    'ecs:RegisterTaskDefinition',   # no new task definitions
+    'ecs:RunTask',
+    'ecs:ExecuteCommand',           # no shell inside a running container
+    'lambda:UpdateFunctionCode',
+    'iam:PassRole',
+    'sts:GetFederationToken',       # the S3 federator's escape hatch
+    'sts:AssumeRole',               # no chaining into another role
+]
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+@pytest.mark.parametrize('action', FORBIDDEN_ACTIONS)
+def test_broad_privilege_is_explicitly_denied_on_both_roles(logical_id, action):
+    role = _role(_build_template(**ENABLED_BOTH), logical_id)
+    assert action in _denied_actions(role), f'{action} is not denied on {logical_id}'
+    assert not _statements_allowing(role, action)
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_both_roles_carry_the_permission_boundary(logical_id):
+    template = _build_template(**ENABLED_BOTH)
+    assert template['Resources'][BOUNDARY_ID]['Type'] == 'AWS::IAM::ManagedPolicy'
+    assert _role(template, logical_id)['PermissionsBoundary'] == {'Ref': BOUNDARY_ID}
+
+
+def test_boundary_is_a_ceiling_not_an_administrative_grant():
+    """ A boundary with no Allow grants nothing and makes both roles unusable, so the single
+        Allow *:* is structural. The roles themselves never grant Action '*' (asserted above).
     """
-    template = _build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS))
-    ecs_policy_names = {p['PolicyName']
-                        for p in _role(template, 'CGAPECSRole')['Policies']}
-    for logical_id in (C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE):
-        human_policy_names = {p['PolicyName'] for p in _role(template, logical_id)['Policies']}
-        assert not (human_policy_names & ecs_policy_names)
-        # None of the runtime role's blanket grants may appear.
-        rendered = _flat(_role(template, logical_id)['Policies'])
-        for blanket in ('"ecs:*"', '"es:*"', '"sqs:*"', '"elasticloadbalancing:*"'):
-            assert blanket not in rendered, f'{logical_id} reuses the blanket grant {blanket}'
+    boundary = _build_template(**ENABLED_BOTH)['Resources'][BOUNDARY_ID]['Properties']
+    document = boundary['PolicyDocument']
+    allows = [s for s in document['Statement'] if s['Effect'] == 'Allow']
+    assert len(allows) == 1
+    assert allows[0]['Sid'] == 'CeilingOnly'
+    assert allows[0]['Action'] == '*'
+    assert 'ceiling' in boundary['Description'].lower()
 
 
-@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
+def test_boundary_forbids_identity_infrastructure_and_destructive_operations():
+    document = _build_template(**ENABLED_BOTH)['Resources'][BOUNDARY_ID]['Properties'][
+        'PolicyDocument']
+    denied = {action for s in document['Statement'] if s['Effect'] == 'Deny'
+              for action in _actions(s)}
+    for action in ('iam:Create*', 'iam:Attach*', 'iam:PassRole', 'sso-admin:*', 'organizations:*',
+                   'cloudformation:UpdateStack', 'cloudformation:ExecuteChangeSet',
+                   'ecr:PutImage', 'lambda:UpdateFunctionCode', 'ec2:AuthorizeSecurityGroup*',
+                   'sqs:PurgeQueue', 'sqs:DeleteQueue', 'rds:Delete*', 's3:PutObject*'):
+        assert action in denied, f'boundary does not forbid {action}'
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
 def test_every_role_denies_activity_outside_the_deployment_region(logical_id):
     role = _role(_build_template(**ENABLED_BOTH), logical_id)
     region_denies = [s for s in _statements(role)
@@ -639,31 +596,104 @@ def test_every_role_denies_activity_outside_the_deployment_region(logical_id):
         'StringNotEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
 
 
+def test_human_roles_do_not_reuse_the_ecs_runtime_role_policies():
+    """ dev_user_role() shares four inline policy objects with the ECS runtime role, which is what
+        makes human access a superset of runtime privilege. These roles must not repeat that.
+    """
+    template = _build_template(**ENABLED_BOTH)
+    ecs_policy_names = {p['PolicyName'] for p in _role(template, 'CGAPECSRole')['Policies']}
+    for logical_id in BOTH_ROLES:
+        human_policy_names = {p['PolicyName'] for p in _role(template, logical_id)['Policies']}
+        assert not (human_policy_names & ecs_policy_names)
+
+
 def test_policies_fit_within_aws_iam_size_limits():
     """ Guards against a future addition silently breaking the deploy: AWS caps a role's inline
         policies at 10240 characters in total, and a managed policy document at 6144.
     """
-    template = _build_template(**dict(ENABLED_BOTH, **dict(REMEDIATION_TARGETS, **{
-        Settings.S3_ENCRYPT_KEY_ID: TEST_KMS_KEY_ID,
-        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True,
-        Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE: True,
-    })))
-    for logical_id in (C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE):
+    template = _build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True}))
+    for logical_id in BOTH_ROLES:
         size = sum(len(json.dumps(p['PolicyDocument'], separators=(',', ':')))
                    for p in _role(template, logical_id)['Policies'])
         assert size <= 10240, f'{logical_id} inline policies are {size} characters'
-    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
+    boundary = template['Resources'][BOUNDARY_ID]['Properties']['PolicyDocument']
     boundary_size = len(json.dumps(boundary, separators=(',', ':')))
     assert boundary_size <= 6144, f'boundary policy is {boundary_size} characters'
 
 
-def test_enabled_template_adds_only_the_expected_resources():
-    template = _build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS))
-    added = set(template['Resources']) - PRE_EXISTING_RESOURCES
-    assert added == {C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE, 'C4IAMMainHumanAccessBoundary'}
-    added_outputs = set(template['Outputs']) - PRE_EXISTING_OUTPUTS
-    assert added_outputs == {f'C4IAMMain{C4IAM.DIAGNOSE_ROLE}Name',
-                             f'C4IAMMain{C4IAM.REMEDIATE_ROLE}Name'}
-    # The opt-in outputs are not exported: no other stack should depend on this feature.
-    for output in added_outputs:
-        assert 'Export' not in template['Outputs'][output]
+# ---------------------------------------------------------------------------------------------
+# 6. The README's illustrative policy examples
+# ---------------------------------------------------------------------------------------------
+
+README_HEADINGS = {
+    C4IAM.DIAGNOSE_ROLE: '### Illustrative policy: diagnostic role',
+    C4IAM.REMEDIATE_ROLE: '### Illustrative policy: remediation role',
+}
+
+
+def _readme_policy(logical_id: str) -> dict:
+    """ Extracts the JSON policy document from the fenced block following a role's heading.
+
+        Anchored on the heading rather than on block position, so adding an unrelated snippet
+        elsewhere in the README cannot silently retarget this.
+    """
+    text = io.open(README).read()
+    heading = README_HEADINGS[logical_id]
+    assert heading in text, f'README is missing the heading {heading!r}'
+    after_heading = text.split(heading, 1)[1]
+    match = re.search(r'```json\n(.*?)\n```', after_heading, re.DOTALL)
+    assert match, f'no fenced json block follows {heading!r}'
+    return json.loads(match.group(1))
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_readme_policy_example_is_valid_and_well_formed(logical_id):
+    document = _readme_policy(logical_id)
+    assert document['Version'] == '2012-10-17'
+    assert isinstance(document['Statement'], list) and document['Statement']
+    for statement in document['Statement']:
+        assert statement['Effect'] in ('Allow', 'Deny')
+        assert 'Sid' in statement
+        assert _actions(statement), f"{statement['Sid']} has no actions"
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_readme_policy_example_matches_what_the_template_renders(logical_id):
+    """ Makes "aligned with the generated policy" a fact rather than a claim.
+
+        Compared by {Sid: sorted(actions)}: resources are deliberately not compared, because the
+        README uses <region>/<account-id> placeholders where the template emits Ref intrinsics.
+    """
+    generated = _action_map(_role(_build_template(**ENABLED_BOTH), logical_id))
+    documented = {s['Sid']: sorted(_actions(s)) for s in _readme_policy(logical_id)['Statement']}
+    assert documented == generated
+
+
+@pytest.mark.parametrize('logical_id', BOTH_ROLES)
+def test_readme_policy_example_is_not_presented_as_deployable(logical_id):
+    """ The examples must not look copy-pasteable: placeholders, not real account values, and no
+        CloudFormation intrinsics left in.
+    """
+    document = _readme_policy(logical_id)
+    rendered = _flat(document)
+    assert '"Ref"' not in rendered and 'Fn::Join' not in rendered
+    assert '<account-id>' in rendered
+    assert not re.search(r'\b\d{12}\b', rendered), 'a real-looking account id appears'
+    # No Action '*' in the illustration either.
+    for statement in document['Statement']:
+        if statement['Effect'] == 'Allow':
+            assert '*' not in _actions(statement)
+
+
+def test_readme_labels_the_examples_non_authoritative_and_explains_the_scoping():
+    text = io.open(README).read()
+    section = text.split('## Human Direct AWS Access Roles', 1)[1].split('\n## ', 1)[0]
+    # Explicitly non-authoritative, and points at the real source of truth.
+    assert 'illustrative, not authoritative' in section
+    assert 'src/parts/iam.py' in section
+    assert 'not deployable as written' in section
+    # Explains both halves of the scoping model, and the action constraint.
+    assert 'service-level' in section.lower()
+    assert 'aws:RequestedRegion' in section
+    assert 'ceiling, not a grant' in section

--- a/tests/test_human_access_roles.py
+++ b/tests/test_human_access_roles.py
@@ -1,0 +1,669 @@
+"""
+Static/template tests for the opt-in human direct-AWS-access roles built by C4IAM.
+
+These roles exist so a developer can inspect the running system, and a power user can perform a
+small number of named, reversible operational writes, without assuming the existing DevRole
+(which is trusted by the account root and holds ten full-access managed policies).
+
+What is pinned here, in the order the requirements were stated:
+
+  1. Disabled by default. With none of the human_access.* settings present, the IAM template is
+     exactly what it was before - same resources, same outputs, no CloudFormation Parameters and
+     no Conditions. A role is also not created when it is enabled but no approved principal ARNs
+     were supplied, because the alternative (account-root trust) is the thing being fixed.
+  2. Trust is restricted to enumerated principal ARNs with an attributable session, never to
+     arn:aws:iam::<account>:root.
+  3. The diagnostic role keeps resource-scoped Secrets Manager and S3 object reads, plus the
+     observability reads needed to inspect services - and nothing on '*' that mutates.
+  4. Broad privilege is denied: no managed policies at all, no supply-chain or identity writes,
+     and every remediation write is on an explicitly supplied ARN.
+
+Physical identifiers asserted here are derived the same way the rest of the repo derives them
+(names.py for secrets, base.py bucket templates, C4Logging's stack name for log groups), so these
+tests fail if that derivation drifts rather than encoding a second guess at the real names.
+"""
+import json
+from unittest import mock
+
+import pytest
+
+from src.c4name import C4Name
+from src.constants import Settings
+from src.part import C4Tags, C4Account
+from src.parts import iam as iam_mod
+from src.parts.iam import C4IAM
+from src.parts.logging import C4Logging
+from troposphere import Template
+
+
+TEST_ENV_NAME = 'cgap-build'
+TEST_ACCOUNT = '123456789'
+ALICE = 'arn:aws:iam::123456789:user/alice'
+BOB = 'arn:aws:iam::123456789:user/bob'
+SSO_PRINCIPAL = ('arn:aws:iam::123456789:role/aws-reserved/sso.amazonaws.com/'
+                 'AWSReservedSSO_Developer_abc123')
+TEST_KMS_KEY_ID = '27d040a3-ead1-4f5a-94ce-0fa6e7f84a95'
+
+SERVICE_ARN = 'arn:aws:ecs:us-east-1:123456789:service/some-cluster/portal'
+CLUSTER_ARN = 'arn:aws:ecs:us-east-1:123456789:cluster/some-cluster'
+QUEUE_ARN = 'arn:aws:sqs:us-east-1:123456789:cgap-build-indexer'
+STATE_MACHINE_ARN = 'arn:aws:states:us-east-1:123456789:stateMachine:tibanna_unicorn'
+CODEBUILD_ARN = 'arn:aws:codebuild:us-east-1:123456789:project/main-build'
+
+# The IAM stack as it stands before any of this is enabled.
+PRE_EXISTING_RESOURCES = {
+    'C4IAMMainApplicationS3Federator',
+    'CGAPDevRole',
+    'CGAPECSAutoscalingRole',
+    'CGAPECSInstanceProfile',
+    'CGAPECSRole',
+    'VPCFlowLogRole',
+}
+PRE_EXISTING_OUTPUTS = {
+    'C4IAMMainECSAssumedIAMRole',
+    'C4IAMMainECSAutoscalingIAMRole',
+    'C4IAMMainECSDevUserRole',
+    'C4IAMMainECSInstanceProfile',
+    'C4IAMMainECSS3IAMUser',
+}
+
+BASE_CONFIG = {
+    Settings.APP_KIND: 'cgap',
+    Settings.ENV_NAME: TEST_ENV_NAME,
+    Settings.ACCOUNT_NUMBER: TEST_ACCOUNT,
+}
+_MISSING = object()
+
+# Everything needed to actually get both roles built.
+ENABLED_BOTH = {
+    Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED: True,
+    Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: f'{ALICE}, {BOB}',
+    Settings.HUMAN_ACCESS_REMEDIATE_ENABLED: True,
+    Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS: ALICE,
+}
+REMEDIATION_TARGETS = {
+    Settings.HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS: SERVICE_ARN,
+    Settings.HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS: CLUSTER_ARN,
+    Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS: QUEUE_ARN,
+    Settings.HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS: STATE_MACHINE_ARN,
+    Settings.HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS: CODEBUILD_ARN,
+}
+
+
+def _make_iam_part() -> C4IAM:
+    name = C4Name('c4-iam-main', title_token='C4IAMMain')
+    return C4IAM(name=name, tags=C4Tags(),
+                 account=C4Account(account_number=TEST_ACCOUNT, creds_file='/dev/null'))
+
+
+def _build_template(**overrides) -> dict:
+    """ Builds the IAM template with the given human_access.* settings in effect.
+
+        Note the per-setting side_effect: a single return_value would make every config lookup
+        answer the same thing, and these tests turn on some settings while leaving others off.
+    """
+    config = dict(BASE_CONFIG)
+    config.update(overrides)
+
+    def fake_get_config_setting(var, default=_MISSING, **kwargs):
+        if var in config:
+            return config[var]
+        if default is _MISSING:
+            raise KeyError(var)
+        return default
+
+    with mock.patch.object(iam_mod.ConfigManager, 'get_config_setting',
+                           side_effect=fake_get_config_setting):
+        return _make_iam_part().build_template(Template()).to_dict()
+
+
+def _role(template: dict, logical_id: str) -> dict:
+    assert logical_id in template['Resources'], f'{logical_id} was not built'
+    return template['Resources'][logical_id]['Properties']
+
+
+def _statements(role_properties: dict) -> list:
+    return [statement
+            for policy in role_properties.get('Policies', [])
+            for statement in policy['PolicyDocument']['Statement']]
+
+
+def _actions(statement: dict) -> list:
+    actions = statement.get('Action', statement.get('NotAction', []))
+    return actions if isinstance(actions, list) else [actions]
+
+
+def _statements_allowing(role_properties: dict, action: str) -> list:
+    return [s for s in _statements(role_properties)
+            if s['Effect'] == 'Allow' and action in _actions(s)]
+
+
+def _denied_actions(role_properties: dict) -> set:
+    return {action
+            for statement in _statements(role_properties)
+            if statement['Effect'] == 'Deny'
+            for action in _actions(statement)}
+
+
+def _resources(statement: dict) -> list:
+    resources = statement.get('Resource', statement.get('NotResource', []))
+    return resources if isinstance(resources, list) else [resources]
+
+
+def _flat(value) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------------------------
+# 1. Disabled by default
+# ---------------------------------------------------------------------------------------------
+
+def test_human_access_roles_are_absent_by_default():
+    """ The whole point of the opt-in: with no configuration, nothing is added. """
+    template = _build_template()
+    assert set(template['Resources']) == PRE_EXISTING_RESOURCES
+    assert set(template['Outputs']) == PRE_EXISTING_OUTPUTS
+    # No CloudFormation Parameters or Conditions were introduced either, so applying this to an
+    # existing stack cannot prompt for a new parameter value.
+    assert 'Parameters' not in template
+    assert 'Conditions' not in template
+    rendered = _flat(template)
+    for token in ('HumanAccess', 'Diagnose', 'Remediate', 'human_access'):
+        assert token not in rendered, f'{token!r} leaked into the default template'
+
+
+def test_default_template_still_contains_the_untouched_dev_role():
+    """ This work adds roles; it does not change or retire the existing DevRole. """
+    dev_role = _role(_build_template(), 'CGAPDevRole')
+    assert len(dev_role['ManagedPolicyArns']) == 10
+    assert dev_role['AssumeRolePolicyDocument']['Statement'][0]['Principal'] == {
+        'AWS': {'Ref': 'AWS::AccountId'}}
+
+
+@pytest.mark.parametrize('enabled_setting, principals_setting, logical_id', [
+    (Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED, Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS,
+     C4IAM.DIAGNOSE_ROLE),
+    (Settings.HUMAN_ACCESS_REMEDIATE_ENABLED, Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS,
+     C4IAM.REMEDIATE_ROLE),
+])
+def test_enabling_without_approved_principals_creates_nothing(enabled_setting, principals_setting,
+                                                              logical_id):
+    """ Fails closed rather than falling back to account-root trust. """
+    template = _build_template(**{enabled_setting: True})
+    assert logical_id not in template['Resources']
+    assert set(template['Resources']) == PRE_EXISTING_RESOURCES
+
+    # ... and an empty string is treated the same as absent.
+    template = _build_template(**{enabled_setting: True, principals_setting: '  ,  '})
+    assert logical_id not in template['Resources']
+
+
+def test_each_role_can_be_enabled_independently():
+    template = _build_template(**{Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED: True,
+                                  Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: ALICE})
+    assert C4IAM.DIAGNOSE_ROLE in template['Resources']
+    assert C4IAM.REMEDIATE_ROLE not in template['Resources']
+
+    template = _build_template(**{Settings.HUMAN_ACCESS_REMEDIATE_ENABLED: True,
+                                  Settings.HUMAN_ACCESS_REMEDIATE_PRINCIPALS: ALICE})
+    assert C4IAM.REMEDIATE_ROLE in template['Resources']
+    assert C4IAM.DIAGNOSE_ROLE not in template['Resources']
+
+
+# ---------------------------------------------------------------------------------------------
+# 2. Trust restrictions
+# ---------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
+def test_trust_policy_never_trusts_the_account_root(logical_id):
+    template = _build_template(**ENABLED_BOTH)
+    trust = _flat(_role(template, logical_id)['AssumeRolePolicyDocument'])
+    assert 'AWS::AccountId' not in trust
+    assert ':root' not in trust
+
+
+def test_trust_policy_pins_exactly_the_supplied_principals():
+    template = _build_template(**ENABLED_BOTH)
+    diagnose_trust = _role(template, C4IAM.DIAGNOSE_ROLE)['AssumeRolePolicyDocument']
+    allow = diagnose_trust['Statement'][0]
+    assert allow['Effect'] == 'Allow'
+    assert allow['Principal'] == {'AWS': [ALICE, BOB]}
+    assert '*' not in allow['Principal']['AWS']
+
+    # The remediation role has its own, smaller principal list.
+    remediate_trust = _role(template, C4IAM.REMEDIATE_ROLE)['AssumeRolePolicyDocument']
+    assert remediate_trust['Statement'][0]['Principal'] == {'AWS': [ALICE]}
+
+
+def test_trust_policy_requires_an_attributable_mfa_session():
+    template = _build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_SOURCE_IDENTITY_PATTERN: '*@hms.harvard.edu'}))
+    trust = _role(template, C4IAM.DIAGNOSE_ROLE)['AssumeRolePolicyDocument']
+    allow_condition = trust['Statement'][0]['Condition']
+    assert allow_condition['Bool'] == {'aws:MultiFactorAuthPresent': 'true'}
+    assert allow_condition['NumericLessThan'] == {'aws:MultiFactorAuthAge': '3600'}
+    assert allow_condition['StringLike'] == {'sts:SourceIdentity': '*@hms.harvard.edu'}
+
+    # A session with no SourceIdentity is refused outright, so CloudTrail always names a person.
+    deny = trust['Statement'][1]
+    assert deny['Effect'] == 'Deny'
+    assert deny['Condition'] == {'Null': {'sts:SourceIdentity': 'true'}}
+
+    # There is no sts:DurationSeconds condition key; MaxSessionDuration is the real control.
+    assert 'DurationSeconds' not in _flat(trust)
+
+
+def test_session_duration_is_bounded_and_shorter_for_remediation():
+    template = _build_template(**ENABLED_BOTH)
+    diagnose = _role(template, C4IAM.DIAGNOSE_ROLE)
+    remediate = _role(template, C4IAM.REMEDIATE_ROLE)
+    assert diagnose['MaxSessionDuration'] == 3600
+    assert remediate['MaxSessionDuration'] == 1800
+    assert remediate['MaxSessionDuration'] < diagnose['MaxSessionDuration']
+
+
+def test_mfa_condition_can_be_dropped_for_sso_accounts_without_losing_attribution():
+    """ In an Identity Center account aws:MultiFactorAuthPresent is asserted upstream and cannot be
+        relied on; the principal pin and SourceIdentity requirement still stand.
+    """
+    template = _build_template(**{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ENABLED: True,
+        Settings.HUMAN_ACCESS_DIAGNOSE_PRINCIPALS: SSO_PRINCIPAL,
+        Settings.HUMAN_ACCESS_REQUIRE_MFA: False,
+    })
+    trust = _role(template, C4IAM.DIAGNOSE_ROLE)['AssumeRolePolicyDocument']
+    assert 'MultiFactorAuthPresent' not in _flat(trust)
+    assert trust['Statement'][0]['Principal'] == {'AWS': [SSO_PRINCIPAL]}
+    assert trust['Statement'][1]['Condition'] == {'Null': {'sts:SourceIdentity': 'true'}}
+    # Not a back door to account-root trust.
+    assert 'AWS::AccountId' not in _flat(trust)
+
+
+# ---------------------------------------------------------------------------------------------
+# 3. Approved diagnostic reads
+# ---------------------------------------------------------------------------------------------
+
+DIAGNOSTIC_READS = [
+    'ecs:Describe*',                # is the portal up, why did a task die
+    'ecs:List*',
+    'elasticloadbalancing:Describe*',  # are target groups healthy
+    'cloudwatch:Get*',              # is RDS saturated, is OpenSearch red
+    'logs:Describe*',
+    'rds:Describe*',
+    'sqs:GetQueueAttributes',       # is indexing backed up (depth, not message bodies)
+    'cloudformation:Describe*',     # did the last deploy succeed
+    'ecr:Describe*',                # which image is actually running
+    'es:Describe*',
+    'ec2:Describe*',
+]
+
+
+@pytest.mark.parametrize('action', DIAGNOSTIC_READS)
+def test_diagnostic_role_allows_the_approved_observability_reads(action):
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    allowing = _statements_allowing(diagnose, action)
+    assert allowing, f'{action} is not allowed to the diagnostic role'
+    # These APIs have no resource-level authorization, so they are on '*' but region-pinned.
+    for statement in allowing:
+        assert statement['Condition'] == {'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
+
+
+def test_diagnostic_role_can_read_application_logs_scoped_to_this_deployment():
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    allowing = _statements_allowing(diagnose, 'logs:FilterLogEvents')
+    assert len(allowing) == 1
+    resources = _resources(allowing[0])
+    rendered = _flat(resources)
+    # Log groups have no LogGroupName, so their physical names are CloudFormation-generated and
+    # can only be matched by the logging stack's prefix. Derive it rather than restating it.
+    assert f'{C4Logging.suggest_stack_name().stack_name}-*' in rendered
+    assert f'/aws/rds/instance/rds-{TEST_ENV_NAME}/*' in rendered
+    # Every ARN is a scoped Fn::Join, never a bare '*' matching every log group in the account.
+    # (A '*' does appear inside them as the log-stream segment, which is expected.)
+    assert resources and all(resource != '*' for resource in resources)
+
+
+def test_diagnostic_secret_reads_are_retained_but_resource_scoped():
+    """ Captain decision: developers keep direct Secrets Manager reads, scoped to the application's
+        own secrets, so they can inspect the system and bring evidence.
+    """
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    allowing = _statements_allowing(diagnose, 'secretsmanager:GetSecretValue')
+    assert allowing, 'the diagnostic role must retain GetSecretValue'
+    assert len(allowing) == 1
+    resources = _flat(_resources(allowing[0]))
+    # The real secret names, per names.py: the app configuration (GAC) and the RDS master secret.
+    assert 'C4AppConfigCgapBuild' in resources
+    assert 'C4DatastoreCgapBuildRDSSecret' in resources
+    # Never the ECS role's unscoped grant.
+    assert '"*"' not in resources
+    assert 'GetSecretValue' not in _denied_actions(diagnose)
+
+
+def test_diagnostic_object_reads_are_retained_but_scoped_to_application_buckets():
+    """ Same decision for S3 objects: kept, but only in this deployment's own buckets. """
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    allowing = _statements_allowing(diagnose, 's3:GetObject')
+    assert allowing, 'the diagnostic role must retain s3:GetObject'
+    assert len(allowing) == 1
+    resources = _resources(allowing[0])
+    assert resources, 'no buckets were scoped'
+    for resource in resources:
+        assert resource.startswith(f'arn:aws:s3:::{TEST_ENV_NAME}-'), resource
+        assert resource.endswith('/*'), resource
+    # Derived from base.py's bucket templates, so the real application buckets are covered.
+    assert f'arn:aws:s3:::{TEST_ENV_NAME}-application-files/*' in resources
+    assert f'arn:aws:s3:::{TEST_ENV_NAME}-application-wfoutput/*' in resources
+    assert 's3:GetObject' not in _denied_actions(diagnose)
+
+
+def test_diagnostic_bucket_list_can_be_supplied_explicitly_for_legacy_names():
+    """ Not every environment's buckets follow the derived pattern, so the list is overridable. """
+    diagnose = _role(_build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_BUCKETS: 'foursight-prod-envs, legacy-application-files',
+    })), C4IAM.DIAGNOSE_ROLE)
+    resources = _resources(_statements_allowing(diagnose, 's3:GetObject')[0])
+    assert resources == ['arn:aws:s3:::foursight-prod-envs/*',
+                         'arn:aws:s3:::legacy-application-files/*']
+
+
+def test_kms_decrypt_is_off_by_default_and_scoped_to_the_configured_key_when_enabled():
+    with_key = dict(ENABLED_BOTH, **{Settings.S3_ENCRYPT_KEY_ID: TEST_KMS_KEY_ID})
+
+    # Off by default: metadata only, and Decrypt is explicitly denied.
+    diagnose = _role(_build_template(**with_key), C4IAM.DIAGNOSE_ROLE)
+    assert not _statements_allowing(diagnose, 'kms:Decrypt')
+    assert 'kms:Decrypt' in _denied_actions(diagnose)
+    assert _statements_allowing(diagnose, 'kms:DescribeKey')
+    # The more revealing key-policy read is scoped to the configured key.
+    key_policy_reads = _statements_allowing(diagnose, 'kms:GetKeyPolicy')
+    assert len(key_policy_reads) == 1
+    assert f'key/{TEST_KMS_KEY_ID}' in _flat(_resources(key_policy_reads[0]))
+
+    # Enabled: allowed on exactly the one configured key, never '*', and no longer denied.
+    diagnose = _role(_build_template(**dict(
+        with_key, **{Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True})), C4IAM.DIAGNOSE_ROLE)
+    allowing = _statements_allowing(diagnose, 'kms:Decrypt')
+    assert len(allowing) == 1
+    resources = _flat(_resources(allowing[0]))
+    assert f'key/{TEST_KMS_KEY_ID}' in resources
+    assert '"*"' not in resources
+    assert 'kms:Decrypt' not in _denied_actions(diagnose)
+
+
+def test_no_key_material_access_without_a_configured_key_but_metadata_still_readable():
+    """ Never a '*' fallback for Decrypt or for the key-policy read when s3.encrypt_key_id is
+        unset - which is the common case, only smaht-wolf configures one. Plain key metadata stays
+        available so "is this bucket encrypted, and with which key" remains answerable.
+    """
+    diagnose = _role(_build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True})), C4IAM.DIAGNOSE_ROLE)
+    assert not _statements_allowing(diagnose, 'kms:Decrypt')
+    assert not _statements_allowing(diagnose, 'kms:GetKeyPolicy')
+
+    metadata_reads = _statements_allowing(diagnose, 'kms:DescribeKey')
+    assert len(metadata_reads) == 1
+    # Metadata only, and region-pinned: no key material, no ciphertext, no key policy.
+    assert metadata_reads[0]['Condition'] == {
+        'StringEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
+    granted = set(_actions(metadata_reads[0]))
+    assert not granted & {'kms:Decrypt', 'kms:GenerateDataKey', 'kms:ReEncryptFrom',
+                          'kms:GetKeyPolicy', 'kms:CreateGrant'}
+
+
+# ---------------------------------------------------------------------------------------------
+# 4. Denied broad privilege
+# ---------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
+def test_neither_role_attaches_any_managed_policy(logical_id):
+    """ The ten managed policies on DevRole are what make it a superset of the runtime role. """
+    role = _role(_build_template(**ENABLED_BOTH), logical_id)
+    assert 'ManagedPolicyArns' not in role
+    assert 'arn:aws:iam::aws:policy/' not in _flat(role)
+
+
+@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
+def test_both_roles_carry_the_permission_boundary(logical_id):
+    template = _build_template(**ENABLED_BOTH)
+    role = _role(template, logical_id)
+    boundary_id = 'C4IAMMainHumanAccessBoundary'
+    assert template['Resources'][boundary_id]['Type'] == 'AWS::IAM::ManagedPolicy'
+    assert role['PermissionsBoundary'] == {'Ref': boundary_id}
+
+
+# Privileges neither human role may hold, each tied to why it matters.
+FORBIDDEN_ACTIONS = [
+    'ecr:PutImage',                 # authoring image content is CI's job, not a human's
+    'ecr:InitiateLayerUpload',
+    'ecs:RegisterTaskDefinition',   # no new task definitions
+    'ecs:RunTask',
+    'ecs:ExecuteCommand',           # no shell inside a running container
+    'iam:PassRole',
+    'sts:GetFederationToken',       # the S3 federator's escape hatch
+    'sts:AssumeRole',               # no chaining into another role
+]
+
+
+@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
+@pytest.mark.parametrize('action', FORBIDDEN_ACTIONS)
+def test_broad_privilege_is_explicitly_denied_on_both_roles(logical_id, action):
+    role = _role(_build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS)), logical_id)
+    assert action in _denied_actions(role), f'{action} is not denied on {logical_id}'
+    assert not _statements_allowing(role, action)
+
+
+def test_diagnostic_role_is_read_only():
+    """ Every write the remediation role may do is denied here, so the two are not interchangeable.
+    """
+    diagnose = _role(_build_template(**ENABLED_BOTH), C4IAM.DIAGNOSE_ROLE)
+    denied = _denied_actions(diagnose)
+    for action in ('ecs:UpdateService', 'ecs:StopTask', 'sqs:PurgeQueue', 'codebuild:StartBuild',
+                   'states:StartExecution', 's3:PutObject', 's3:DeleteObject',
+                   'secretsmanager:PutSecretValue', 'cloudwatch:PutMetricAlarm'):
+        assert action in denied, f'{action} is not denied to the read-only role'
+    # Data-plane and configuration exfiltration paths that a read-only role must not have.
+    for action in ('sqs:ReceiveMessage', 'rds:DownloadCompleteDBLogFile',
+                   'lambda:GetFunctionConfiguration', 'ssm:GetParameter'):
+        assert action in denied, f'{action} is not denied to the read-only role'
+
+
+def test_no_mutating_action_is_ever_granted_on_a_wildcard_resource():
+    template = _build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS))
+    mutating_verbs = ('Update', 'Delete', 'Create', 'Put', 'Purge', 'Start', 'Stop', 'Retry',
+                      'Register', 'Run', 'Execute', 'Modify', 'Restore', 'Reboot')
+    read_only_exceptions = {'logs:StartQuery', 'logs:StopQuery', 'sts:GetCallerIdentity'}
+    for logical_id in (C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE):
+        for statement in _statements(_role(template, logical_id)):
+            if statement['Effect'] != 'Allow':
+                continue
+            for action in _actions(statement):
+                if action in read_only_exceptions or not any(v in action for v in mutating_verbs):
+                    continue
+                assert '*' not in _resources(statement), (
+                    f'{logical_id} grants {action} on a wildcard resource')
+
+
+def test_boundary_bounds_the_scoped_reads_instead_of_dropping_the_deny():
+    """ The boundary opens with Allow *:*, so simply removing s3:GetObject / GetSecretValue from
+        its deny list would permit them on everything. They are denied via NotResource instead.
+    """
+    template = _build_template(**dict(ENABLED_BOTH, **{
+        Settings.S3_ENCRYPT_KEY_ID: TEST_KMS_KEY_ID,
+        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True,
+    }))
+    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
+    carve_outs = {s['Sid']: s for s in boundary['Statement'] if 'NotResource' in s}
+    assert set(carve_outs) == {'BoundS3ObjectReadsToApplicationBuckets',
+                               'BoundSecretReadsToApplicationSecrets',
+                               'BoundKmsUseToConfiguredEncryptionKey'}
+    for statement in carve_outs.values():
+        assert statement['Effect'] == 'Deny'
+        assert statement['NotResource'], 'an empty NotResource would deny nothing'
+        assert '*' not in statement['NotResource']
+    assert 's3:GetObject' in _actions(carve_outs['BoundS3ObjectReadsToApplicationBuckets'])
+    assert 'secretsmanager:GetSecretValue' in _actions(
+        carve_outs['BoundSecretReadsToApplicationSecrets'])
+
+
+def test_boundary_denies_the_scoped_reads_outright_when_there_is_nothing_to_carve_out():
+    """ With no encryption key configured there is no legitimate target, so the deny is absolute. """
+    template = _build_template(**ENABLED_BOTH)
+    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
+    kms_deny = next(s for s in boundary['Statement']
+                    if s['Sid'] == 'BoundKmsUseToConfiguredEncryptionKey')
+    assert 'NotResource' not in kms_deny
+    assert kms_deny['Resource'] == '*'
+    assert kms_deny['Effect'] == 'Deny'
+
+
+def test_boundary_forbids_identity_and_infrastructure_administration():
+    template = _build_template(**ENABLED_BOTH)
+    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
+    denied = {action for s in boundary['Statement'] if s['Effect'] == 'Deny'
+              for action in _actions(s)}
+    for action in ('iam:Create*', 'iam:Attach*', 'iam:PassRole', 'sso-admin:*', 'organizations:*',
+                   'cloudformation:UpdateStack', 'cloudformation:ExecuteChangeSet',
+                   'ecr:PutImage', 'lambda:UpdateFunctionCode', 'ec2:AuthorizeSecurityGroup*'):
+        assert action in denied, f'boundary does not forbid {action}'
+    # It is a boundary, not an administrative grant: the only Allow is the standard Allow *:*
+    # that the deny statements then carve down.
+    allows = [s for s in boundary['Statement'] if s['Effect'] == 'Allow']
+    assert len(allows) == 1
+    assert allows[0]['Action'] == '*'
+
+
+# ---------------------------------------------------------------------------------------------
+# Remediation is narrowly parameterized
+# ---------------------------------------------------------------------------------------------
+
+def test_remediation_has_no_mutating_power_until_target_arns_are_supplied():
+    """ No derived-name, ENV_NAME or wildcard fallback: an unnamed environment is out of reach.
+        This is what keeps a live (green) environment out of scope unless it is named on purpose.
+    """
+    remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
+    policy_names = [p['PolicyName'] for p in remediate['Policies']]
+    assert 'HumanRemediateActionPolicy' not in policy_names
+    for action in ('ecs:UpdateService', 'ecs:StopTask', 'sqs:ChangeMessageVisibility',
+                   'sqs:PurgeQueue', 'states:StartExecution', 'codebuild:StartBuild'):
+        assert not _statements_allowing(remediate, action), f'{action} granted with no target ARN'
+    assert TEST_ENV_NAME not in _flat(remediate['Policies'])
+
+
+@pytest.mark.parametrize('setting, action, expected_resource', [
+    (Settings.HUMAN_ACCESS_REMEDIATE_SERVICE_ARNS, 'ecs:UpdateService', SERVICE_ARN),
+    (Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS, 'sqs:ChangeMessageVisibility', QUEUE_ARN),
+    (Settings.HUMAN_ACCESS_REMEDIATE_STATE_MACHINE_ARNS, 'states:StartExecution',
+     STATE_MACHINE_ARN),
+    (Settings.HUMAN_ACCESS_REMEDIATE_CODEBUILD_ARNS, 'codebuild:StartBuild', CODEBUILD_ARN),
+])
+def test_each_remediation_capability_is_driven_by_its_own_supplied_arns(
+        setting, action, expected_resource):
+    remediate = _role(_build_template(**dict(ENABLED_BOTH, **{setting: expected_resource})),
+                      C4IAM.REMEDIATE_ROLE)
+    allowing = _statements_allowing(remediate, action)
+    assert len(allowing) == 1
+    assert _resources(allowing[0]) == [expected_resource]
+    # Every write is region-pinned and gated on a live MFA session.
+    condition = allowing[0]['Condition']
+    assert condition['Bool'] == {'aws:MultiFactorAuthPresent': 'true'}
+    assert condition['StringEquals'] == {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}
+
+
+def test_stop_task_is_confined_to_the_supplied_cluster():
+    remediate = _role(_build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_REMEDIATE_CLUSTER_ARNS: CLUSTER_ARN})), C4IAM.REMEDIATE_ROLE)
+    allowing = _statements_allowing(remediate, 'ecs:StopTask')
+    assert len(allowing) == 1
+    assert _resources(allowing[0]) == ['arn:aws:ecs:us-east-1:123456789:task/some-cluster/*']
+    assert allowing[0]['Condition']['ArnEquals'] == {'ecs:cluster': [CLUSTER_ARN]}
+
+
+def test_sqs_purge_requires_its_own_explicit_flag_on_top_of_supplied_queues():
+    """ PurgeQueue is irreversible, so having queue ARNs is not enough to get it. """
+    with_queues = dict(ENABLED_BOTH, **{Settings.HUMAN_ACCESS_REMEDIATE_QUEUE_ARNS: QUEUE_ARN})
+
+    remediate = _role(_build_template(**with_queues), C4IAM.REMEDIATE_ROLE)
+    assert not _statements_allowing(remediate, 'sqs:PurgeQueue')
+    # The reversible queue action is still available, i.e. purge is genuinely split out.
+    assert _statements_allowing(remediate, 'sqs:ChangeMessageVisibility')
+
+    remediate = _role(_build_template(**dict(with_queues, **{
+        Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE: True})), C4IAM.REMEDIATE_ROLE)
+    allowing = _statements_allowing(remediate, 'sqs:PurgeQueue')
+    assert len(allowing) == 1
+    assert _resources(allowing[0]) == [QUEUE_ARN]
+
+
+def test_purge_flag_alone_grants_nothing_without_queue_arns():
+    remediate = _role(_build_template(**dict(ENABLED_BOTH, **{
+        Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE: True})), C4IAM.REMEDIATE_ROLE)
+    assert not _statements_allowing(remediate, 'sqs:PurgeQueue')
+
+
+def test_remediation_reads_are_narrower_than_diagnostic_reads():
+    """ Keeps CloudTrail separable into "someone was looking" and "someone was changing". """
+    remediate = _role(_build_template(**ENABLED_BOTH), C4IAM.REMEDIATE_ROLE)
+    for action in ('secretsmanager:GetSecretValue', 's3:GetObject', 'kms:Decrypt'):
+        assert not _statements_allowing(remediate, action)
+        assert action in _denied_actions(remediate)
+
+
+# ---------------------------------------------------------------------------------------------
+# Structural guarantees
+# ---------------------------------------------------------------------------------------------
+
+def test_human_roles_do_not_reuse_the_ecs_runtime_role_policies():
+    """ dev_user_role() shares four inline policy objects with the ECS runtime role, which is what
+        makes human access a superset of runtime privilege. These roles must not repeat that.
+    """
+    template = _build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS))
+    ecs_policy_names = {p['PolicyName']
+                        for p in _role(template, 'CGAPECSRole')['Policies']}
+    for logical_id in (C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE):
+        human_policy_names = {p['PolicyName'] for p in _role(template, logical_id)['Policies']}
+        assert not (human_policy_names & ecs_policy_names)
+        # None of the runtime role's blanket grants may appear.
+        rendered = _flat(_role(template, logical_id)['Policies'])
+        for blanket in ('"ecs:*"', '"es:*"', '"sqs:*"', '"elasticloadbalancing:*"'):
+            assert blanket not in rendered, f'{logical_id} reuses the blanket grant {blanket}'
+
+
+@pytest.mark.parametrize('logical_id', [C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE])
+def test_every_role_denies_activity_outside_the_deployment_region(logical_id):
+    role = _role(_build_template(**ENABLED_BOTH), logical_id)
+    region_denies = [s for s in _statements(role)
+                     if s['Effect'] == 'Deny' and 'NotAction' in s]
+    assert len(region_denies) == 1
+    assert region_denies[0]['Condition'] == {
+        'StringNotEquals': {'aws:RequestedRegion': {'Ref': 'AWS::Region'}}}
+
+
+def test_policies_fit_within_aws_iam_size_limits():
+    """ Guards against a future addition silently breaking the deploy: AWS caps a role's inline
+        policies at 10240 characters in total, and a managed policy document at 6144.
+    """
+    template = _build_template(**dict(ENABLED_BOTH, **dict(REMEDIATION_TARGETS, **{
+        Settings.S3_ENCRYPT_KEY_ID: TEST_KMS_KEY_ID,
+        Settings.HUMAN_ACCESS_DIAGNOSE_ALLOW_KMS_DECRYPT: True,
+        Settings.HUMAN_ACCESS_REMEDIATE_ALLOW_QUEUE_PURGE: True,
+    })))
+    for logical_id in (C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE):
+        size = sum(len(json.dumps(p['PolicyDocument'], separators=(',', ':')))
+                   for p in _role(template, logical_id)['Policies'])
+        assert size <= 10240, f'{logical_id} inline policies are {size} characters'
+    boundary = template['Resources']['C4IAMMainHumanAccessBoundary']['Properties']['PolicyDocument']
+    boundary_size = len(json.dumps(boundary, separators=(',', ':')))
+    assert boundary_size <= 6144, f'boundary policy is {boundary_size} characters'
+
+
+def test_enabled_template_adds_only_the_expected_resources():
+    template = _build_template(**dict(ENABLED_BOTH, **REMEDIATION_TARGETS))
+    added = set(template['Resources']) - PRE_EXISTING_RESOURCES
+    assert added == {C4IAM.DIAGNOSE_ROLE, C4IAM.REMEDIATE_ROLE, 'C4IAMMainHumanAccessBoundary'}
+    added_outputs = set(template['Outputs']) - PRE_EXISTING_OUTPUTS
+    assert added_outputs == {f'C4IAMMain{C4IAM.DIAGNOSE_ROLE}Name',
+                             f'C4IAMMain{C4IAM.REMEDIATE_ROLE}Name'}
+    # The opt-in outputs are not exported: no other stack should depend on this feature.
+    for output in added_outputs:
+        assert 'Export' not in template['Outputs'][output]

--- a/tests/test_setup_remaining_secrets.py
+++ b/tests/test_setup_remaining_secrets.py
@@ -1,7 +1,7 @@
 import mock
 import re
 from typing import Optional
-from src.auto.setup_remaining_secrets.cli import main
+from src.auto.setup_remaining_secrets.cli import main, validate_and_get_gac_secret_name
 from dcicutils.cloudformation_utils import camelize, DEFAULT_ECOSYSTEM
 from dcicutils.qa_utils import printed_output as mock_print, MockBoto3
 from src.names import Names
@@ -86,6 +86,13 @@ def test_setup_remaining_secrets_without_overwriting_existing_secrets() -> None:
     do_test_setup_remaining_secrets(overwrite_secrets=False, create_access_key_pair=False, encryption_enabled=False)
 
 
+def test_gac_fixture_matches_the_default_and_explicit_cli_secret_names() -> None:
+    # Guard against seeding the obsolete datastore key while the CLI reads the appconfig key.
+    assert TestData.gac_secret_name == 'C4AppConfigCgapUnitTest'
+    assert validate_and_get_gac_secret_name(None, TestData.aws_credentials_name) == TestData.gac_secret_name
+    assert validate_and_get_gac_secret_name('explicit-secret', TestData.aws_credentials_name) == 'explicit-secret'
+
+
 def test_get_federated_user_name_pattern() -> None:
     federated_user_name_pattern = Names.ecs_s3_iam_user_logical_id(None,
                                                                    TestData.aws_credentials_name, DEFAULT_ECOSYSTEM)
@@ -108,9 +115,15 @@ def do_test_setup_remaining_secrets(overwrite_secrets: bool = True,
     mocked_secretsmanager = mocked_boto.client("secretsmanager")
     mocked_secret_put = mocked_secretsmanager.put_secret_key_value_for_testing
     mocked_secret_get = mocked_secretsmanager.get_secret_key_value_for_testing
-    mocked_gac_secret_put = lambda key, value: mocked_secret_put(TestData.gac_secret_name, key, value)
-    mocked_gac_secret_get = lambda key: mocked_secret_get(TestData.gac_secret_name, key)
-    mocked_rds_secret_put = lambda key, value: mocked_secret_put(TestData.rds_secret_name, key, value)
+
+    def mocked_gac_secret_put(key, value):
+        return mocked_secret_put(TestData.gac_secret_name, key, value)
+
+    def mocked_gac_secret_get(key):
+        return mocked_secret_get(TestData.gac_secret_name, key)
+
+    def mocked_rds_secret_put(key, value):
+        return mocked_secret_put(TestData.rds_secret_name, key, value)
 
     mocked_rds_secret_put(RdsSecretKeyName.RDS_HOSTNAME, TestData.rds_host)
     mocked_rds_secret_put(RdsSecretKeyName.RDS_PASSWORD, TestData.rds_password)
@@ -202,7 +215,8 @@ def do_test_setup_remaining_secrets(overwrite_secrets: bool = True,
 
         # Mocking input makes import pdb ; pdb.set_trace wig out. Mock yes_or_no instead (2022-12-16/dmichaels).
         # with mock.patch("builtins.input", mocked_input):
-        with mock.patch("src.auto.utils.aws.yes_or_no", mocked_yes_or_no), mock.patch("src.auto.setup_remaining_secrets.cli.yes_or_no", mocked_yes_or_no):
+        with mock.patch("src.auto.utils.aws.yes_or_no", mocked_yes_or_no), \
+             mock.patch("src.auto.setup_remaining_secrets.cli.yes_or_no", mocked_yes_or_no):
 
             main(["--aws-credentials-dir", aws_credentials_dir, "--custom-dir", custom_dir, "--show"])
 


### PR DESCRIPTION
## Summary
- Adds disabled-default diagnosis/remediation IAM roles with explicit principal trust and permission boundaries; existing roles and disabled templates remain unchanged.
- Validates trust inputs/quotas, uses valid session limits and assumption-time MFA, restricts S3 ownership, corrects inspection scopes and conflicting denies, and covers the current appconfig secret fixture.

**Security limits:** both roles enforce a one-hour ceiling; 1800-second remediation sessions are guidance only. Diagnosis can expose credentials. KMS opt-in may authorize decrypt through existing key policies. Remediation deliberately retains CodeBuild overrides and workflow delegation under separately privileged service roles—not a no-arbitrary-code sandbox. See the [operator guide](docs/source/human_access_roles.rst).

## Validation
- 175 offline tests passed, including 142 role tests and 4 secrets tests; changed Python files pass flake8.
- 21 IAM templates pass cfn-lint cleanly across CGAP, Fourfront and SMaHT. All 45 existing-stack templates match current master byte-for-byte.
- Broader validation retains 60 existing lint diagnostics and 63 existing template warnings. Optional blue/green synthesis and Foursight packaging are explicitly unvalidated.

[Failure-causality proof and validation details](docs/pr99-validation.md). No live AWS operations, deployment, role assumption or IAM application performed.
