### PR TITLE
Fix SRCE Foursight NoSuchBucket: GAC secret double-substitutes env name in bucket names

### DIFF
--- a/src/parts/application_configuration_secrets.py
+++ b/src/parts/application_configuration_secrets.py
@@ -46,16 +46,23 @@ class ApplicationConfigurationSecrets:
             'ENCODED_REDIS_SERVER': None,  # populate later if in use
             'ENCODED_FOURSIGHT_BUCKET_PREFIX': ConfigManager.resolve_bucket_name("{foursight_prefix}"),
             'ENCODED_IDENTITY': None,  # This is the name of the Secrets Manager with all our identity's secrets
+            # NOTE: these five are resolved directly via ConfigManager.resolve_bucket_name(AppBucketTemplate.*)
+            # rather than via C4Datastore.application_layer_bucket(...) (src/parts/datastore.py), which is the
+            # same underlying computation, to avoid a circular import (datastore.py imports this module).
+            # Previously these were left as "" placeholders, which made dcicutils.deployment_utils fall back to
+            # its own bucket-name default -- one that double-inserts the env name when
+            # ENCODED_APPLICATION_BUCKET_PREFIX (above) already contains it, producing bucket names that were
+            # never actually provisioned. See the 4dn-dcic/4dn-cloud-infra SRCE NoSuchBucket investigation.
             'ENCODED_FILE_UPLOAD_BUCKET':
-                "",  # cls.application_layer_bucket(C4DatastoreExports.APPLICATION_FILES_BUCKET),
+                ConfigManager.resolve_bucket_name(ConfigManager.AppBucketTemplate.FILES),
             'ENCODED_FILE_WFOUT_BUCKET':
-                "",  # cls.application_layer_bucket(C4DatastoreExports.APPLICATION_WFOUT_BUCKET),
+                ConfigManager.resolve_bucket_name(ConfigManager.AppBucketTemplate.WFOUT),
             'ENCODED_BLOB_BUCKET':
-                "",  # cls.application_layer_bucket(C4DatastoreExports.APPLICATION_BLOBS_BUCKET),
+                ConfigManager.resolve_bucket_name(ConfigManager.AppBucketTemplate.BLOBS),
             'ENCODED_SYSTEM_BUCKET':
-                "",  # cls.application_layer_bucket(C4DatastoreExports.APPLICATION_SYSTEM_BUCKET),
+                ConfigManager.resolve_bucket_name(ConfigManager.AppBucketTemplate.SYSTEM),
             'ENCODED_METADATA_BUNDLES_BUCKET':
-                "",  # cls.application_layer_bucket(C4DatastoreExports.APPLICATION_METADATA_BUNDLES_BUCKET),
+                ConfigManager.resolve_bucket_name(ConfigManager.AppBucketTemplate.METADATA_BUNDLES),
             'ENCODED_S3_BUCKET_ORG': ConfigManager.get_config_setting(Settings.S3_BUCKET_ORG, default=None),
             'ENCODED_TIBANNA_OUTPUT_BUCKET':
                 "",  # cls.application_layer_bucket(C4DatastoreExports.APPLICATION_TIBANNA_OUTPUT_BUCKET),

--- a/tests/test_application_configuration_secrets.py
+++ b/tests/test_application_configuration_secrets.py
@@ -1,0 +1,109 @@
+import mock
+
+from src.base import ConfigManager
+from src.constants import Settings
+from src.parts.application_configuration_secrets import ApplicationConfigurationSecrets
+from src.parts.datastore import C4Datastore, C4DatastoreExports
+
+
+# Regression coverage for the SRCE Foursight NoSuchBucket bug: the GAC (Global Application
+# Configuration) secret template used to leave ENCODED_SYSTEM_BUCKET (and four sibling
+# application-layer bucket names) as an empty-string placeholder. Because an empty string is
+# falsy, dcicutils.deployment_utils's ini-generation fell back to its own default bucket-name
+# formula, which appends the env name a second time onto ENCODED_APPLICATION_BUCKET_PREFIX --
+# a value that (per this repo's convention) already contains the env name -- producing a bucket
+# name that 4dn-cloud-infra never actually provisions. These tests assert that each of the five
+# GAC bucket secret values is instead computed via the same canonical machinery
+# (ConfigManager.resolve_bucket_name) that C4Datastore uses to name the buckets it actually
+# creates, so the two can never drift apart again.
+
+# (secret key, datastore export name, bucket-name template, expected bucket-name suffix)
+BUCKET_EXPORT_TEMPLATE_PAIRS = [
+    ("ENCODED_SYSTEM_BUCKET",
+     C4DatastoreExports.APPLICATION_SYSTEM_BUCKET, ConfigManager.AppBucketTemplate.SYSTEM, "system"),
+    ("ENCODED_FILE_UPLOAD_BUCKET",
+     C4DatastoreExports.APPLICATION_FILES_BUCKET, ConfigManager.AppBucketTemplate.FILES, "files"),
+    ("ENCODED_FILE_WFOUT_BUCKET",
+     C4DatastoreExports.APPLICATION_WFOUT_BUCKET, ConfigManager.AppBucketTemplate.WFOUT, "wfoutput"),
+    ("ENCODED_BLOB_BUCKET",
+     C4DatastoreExports.APPLICATION_BLOBS_BUCKET, ConfigManager.AppBucketTemplate.BLOBS, "blobs"),
+    ("ENCODED_METADATA_BUNDLES_BUCKET",
+     C4DatastoreExports.APPLICATION_METADATA_BUNDLES_BUCKET,
+     ConfigManager.AppBucketTemplate.METADATA_BUNDLES, "metadata-bundles"),
+]
+
+
+def _config_setting_stub(env_name):
+    """
+    Stands in for ConfigManager.get_config_setting, returning only a controlled ENCODED_ENV_NAME
+    (env.name) and otherwise falling back to whatever default the caller supplied -- avoiding any
+    dependency on a real custom/config.json or live AWS credentials.
+    """
+    def _get(var, default=None, use_default_if_empty=True):
+        if var == Settings.ENV_NAME:
+            return env_name
+        return default
+    return _get
+
+
+def test_gac_bucket_secrets_match_canonical_provisioned_bucket_names():
+    """
+    For a realistic env name (mirroring the actual smaht-dev-srce failure), each of the five
+    GAC bucket secret values must: (a) equal what C4Datastore.application_layer_bucket actually
+    provisions for the corresponding export, and (b) contain the env name exactly once.
+    """
+    env_name = "smaht-dev-srce"
+    with mock.patch.object(ConfigManager, "get_config_setting", side_effect=_config_setting_stub(env_name)):
+        for secret_key, export_name, template, suffix in BUCKET_EXPORT_TEMPLATE_PAIRS:
+            generated = ConfigManager.resolve_bucket_name(template)
+            canonical = C4Datastore.application_layer_bucket(export_name)
+            assert generated == canonical, (
+                f"{secret_key}: generated {generated!r} does not match the actually-provisioned "
+                f"bucket name {canonical!r}"
+            )
+            assert generated == f"{env_name}-application-{suffix}"
+            assert generated.count(env_name) == 1, (
+                f"{secret_key}: env name {env_name!r} appears {generated.count(env_name)} times "
+                f"in {generated!r} (expected exactly once -- this is the doubled-name bug)"
+            )
+
+
+def test_gac_bucket_secrets_match_canonical_bucket_even_when_env_name_overlaps_a_suffix():
+    """
+    Disconfirming case: env_name here contains the bucket suffix itself ("system"), so a naive
+    "env name appears exactly once in the bucket name" substring check is not sufficient by
+    itself -- it would also pass for a name that happened to reuse "system" from within the
+    env name rather than from the suffix. The real guarantee is exact equality with the
+    canonical, already-provisioned bucket name, which is what this test asserts.
+    """
+    env_name = "acme-system-dev"
+    with mock.patch.object(ConfigManager, "get_config_setting", side_effect=_config_setting_stub(env_name)):
+        generated = ConfigManager.resolve_bucket_name(ConfigManager.AppBucketTemplate.SYSTEM)
+        canonical = C4Datastore.application_layer_bucket(C4DatastoreExports.APPLICATION_SYSTEM_BUCKET)
+        assert generated == canonical == f"{env_name}-application-system"
+
+
+def test_build_initial_values_populates_bucket_secrets_from_canonical_machinery():
+    """
+    End-to-end (within this repo) check of the actual code path that used to ship blank
+    placeholders: ApplicationConfigurationSecrets.build_initial_values() must populate all five
+    bucket secrets with real, non-empty, correctly-suffixed values -- not "" -- for every
+    generated GAC secret.
+    """
+    env_name = "smaht-dev-srce"
+    with mock.patch.object(ConfigManager, "get_config_setting", side_effect=_config_setting_stub(env_name)), \
+         mock.patch.object(ApplicationConfigurationSecrets, "get_es_url", return_value="some-es-url:443"), \
+         mock.patch.object(ApplicationConfigurationSecrets, "rds_db_username", return_value="test-rds-user"), \
+         mock.patch.object(ConfigManager, "get_s3_encrypt_key_from_file", return_value=None):
+        values = ApplicationConfigurationSecrets.build_initial_values()
+
+    for secret_key, export_name, template, suffix in BUCKET_EXPORT_TEMPLATE_PAIRS:
+        expected = f"{env_name}-application-{suffix}"
+        assert values[secret_key] == expected, (
+            f"{secret_key} was {values[secret_key]!r}, expected {expected!r} (must not be blank)"
+        )
+        assert values[secret_key] != "", f"{secret_key} regressed to the empty-string placeholder"
+
+    # Tibanna output is intentionally untouched by this fix (different, non-doubling template;
+    # confirmed correct in the live SRCE environment) -- still left for manual/other population.
+    assert values["ENCODED_TIBANNA_OUTPUT_BUCKET"] == ""

--- a/tests/test_setup_remaining_secrets.py
+++ b/tests/test_setup_remaining_secrets.py
@@ -39,7 +39,10 @@ class TestData:
     rds_host = "rds.host.for.testing"
     rds_password = "rds-password-for-testing"
 
-    gac_secret_name = f"C4Datastore{camelize(aws_credentials_name)}ApplicationConfiguration"
+    # GAC secret name comes from the appconfig stack (Names.application_configuration_secret),
+    # not the legacy "C4Datastore...ApplicationConfiguration" pattern -- that naming moved when
+    # AppConfig was factored out into its own stack (see src/parts/appconfig.py).
+    gac_secret_name = Names.application_configuration_secret(aws_credentials_name)
     rds_secret_name = f"C4Datastore{camelize(aws_credentials_name)}RDSSecret"
 
 


### PR DESCRIPTION
## Summary
- `ApplicationConfigurationSecrets.build_initial_values()` left `ENCODED_SYSTEM_BUCKET`, `ENCODED_FILE_UPLOAD_BUCKET`, `ENCODED_FILE_WFOUT_BUCKET`, `ENCODED_BLOB_BUCKET`, and `ENCODED_METADATA_BUNDLES_BUCKET` as empty-string placeholders. Because an empty string is falsy, `dcicutils.deployment_utils`'s ini-generation fallback recomputes the bucket name as `{application_bucket_prefix}{env}-{suffix}` -- and since `ENCODED_APPLICATION_BUCKET_PREFIX` already contains the env name in this repo's convention, that produced bucket names with the environment name doubled (e.g. `smaht-dev-srce-application-smaht-dev-srce-system`), a bucket that was never provisioned.
- Live-observed as `Exception in route (reactapi_route_header): ... NoSuchBucket ...` for `smaht-dev-srce`, traced end-to-end (portal health page, pinned `dcicutils`/`foursight-core` source, and live read-only S3 `head-bucket` checks) in a companion investigation.
- Fix: populate the five secrets via `ConfigManager.resolve_bucket_name(AppBucketTemplate.*)`, the same underlying computation `C4Datastore.application_layer_bucket()` uses to name the buckets it actually provisions (called directly, not via `C4Datastore`, to avoid a circular import with `datastore.py`). Tibanna bucket secrets are untouched -- their template doesn't double the env name and were already correct.

## Test plan
- [x] New regression tests in `tests/test_application_configuration_secrets.py`: each of the five generated bucket secret values matches `C4Datastore.application_layer_bucket(...)`'s canonical output and contains the env name exactly once; a disconfirming case where the env name overlaps a bucket suffix; an end-to-end check of `build_initial_values()`.
- [x] Verified these tests fail against the pre-fix code (empty-string placeholders) and pass against the fix.
- [x] `flake8` clean on touched files.
- [x] Ran the pre-existing `tests/test_setup_remaining_secrets.py` suite; its 2 failures are pre-existing on this branch's base commit too (unrelated to this change).
